### PR TITLE
use "rm -f"

### DIFF
--- a/bin/rbenv-rehash
+++ b/bin/rbenv-rehash
@@ -4,7 +4,7 @@ set -e
 
 mkdir -p "${HOME}/.rbenv/shims"
 cd "${HOME}/.rbenv/shims"
-rm *
+rm -f *
 
 for file in ../versions/*/bin/*; do
   ln -fs ../bin/rbenv-shim "${file##*/}"


### PR DESCRIPTION
The first time though, the shims dir is empty, which causes "rm *" to complain (because it matches no files). Changing this to "rm -f *" quiets it.
