### PR TITLE
Use /usr/bin/env rather than /bin/bash

### DIFF
--- a/bin/rbenv
+++ b/bin/rbenv
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 command="$1"
 if [ -z "$command" ]; then

--- a/bin/rbenv-exec
+++ b/bin/rbenv-exec
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 RBENV_COMMAND="$1"
 if [ -z "$RBENV_COMMAND" ]; then

--- a/bin/rbenv-path
+++ b/bin/rbenv-path
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 if [ -n "$1" ]; then
   RBENV_VERSION="$1"

--- a/bin/rbenv-rehash
+++ b/bin/rbenv-rehash
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 mkdir -p "${HOME}/.rbenv/shims"
 cd "${HOME}/.rbenv/shims"

--- a/bin/rbenv-set-default
+++ b/bin/rbenv-set-default
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 RBENV_VERSION="$1"
 if [ -z "$RBENV_VERSION" ]; then

--- a/bin/rbenv-set-local
+++ b/bin/rbenv-set-local
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 RBENV_VERSION="$1"
 if [ -z "$RBENV_VERSION" ]; then

--- a/bin/rbenv-shim
+++ b/bin/rbenv-shim
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 exec rbenv-exec "${0##*/}" "$@"

--- a/bin/rbenv-version
+++ b/bin/rbenv-version
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 read_version_file() {
   egrep -m 1 '[^[:space:]]' "$1"

--- a/bin/rbenv-versions
+++ b/bin/rbenv-versions
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 RBENV_VERSION="$(rbenv-version)"
 

--- a/bin/rbenv-which
+++ b/bin/rbenv-which
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 RBENV_VERSION="$(rbenv-version)"
 RBENV_COMMAND="$1"


### PR DESCRIPTION
More portable in cases where Bash isn't at `/bin/bash` (or people have other versions they prefer somewhere else).
