### PR TITLE
Use parameter expansion for basename + dirname

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -5,8 +5,8 @@ abs_dirname() {
   local path="$1"
 
   while [ -n "$path" ]; do
-    cd "$(dirname "$path")"
-    local name="$(basename "$path")"
+    cd "${path%/*}"
+    local name="${path##*/}"
     path="$(readlink "$name" || true)"
   done
 


### PR DESCRIPTION
These are built-ins, and they're used elsewhere in the code.
