### PR TITLE
Directories in $PATH may not exist 

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -2,10 +2,12 @@
 
 expand_path() {
   local cwd="$(pwd)"
-  if [[ -e $1 ]]; then
+  if [[ -e "$1" ]]; then
     cd "$1"
     pwd
     cd "$cwd"
+  else
+    echo "$1"
   fi
 }
 


### PR DESCRIPTION
It's fairly common for a user to put directory in `$PATH` (e.g., `./.local`) that does not exist in the common case. This patch avoids an error message relating to this possibility.
