### PR TITLE
Use $HOME when specifying installation prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,14 @@ can manually add `$HOME/.rbenv/shims` to your path in step 2.)
 5. Install Ruby versions into `~/.rbenv/versions`. For example, to
 install Ruby 1.9.2-p290, download and unpack the source, then run:
 
-        $ ./configure --prefix=~/.rbenv/versions/1.9.2-p290
+        $ ./configure --prefix=$HOME/.rbenv/versions/1.9.2-p290
         $ make
         $ make install
 
     The [ruby-build](https://github.com/sstephenson/ruby-build)
     project simplifies this process to a single command:
 
-        $ ruby-build 1.9.2-p290 ~/.rbenv/versions/1.9.2-p290
+        $ ruby-build 1.9.2-p290 $HOME/.rbenv/versions/1.9.2-p290
 
 6. Rebuild the shim binaries. You should do this any time you install
 a new Ruby binary (for example, when installing a new Ruby version, or


### PR DESCRIPTION
I received this error when following the README for installing 1.9.2 from source using an install prefix.

```
  configure: error: expected an absolute directory name for --prefix: ~/.rbenv/versions/1.9.2-p290
```

I replaced `~` with `$HOME` and it worked as intended. So I updated the README to reflex this.
