### PR TITLE
--help / -h should work as expected

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -19,10 +19,11 @@ libexec_path="$(abs_dirname "$0")"
 export PATH="${libexec_path}:${PATH}"
 
 command="$1"
-if [ -z "$command" ]; then
+case $command in
+"" | "-h" | "--help")
   echo -e "rbenv 0.1.0\n$(rbenv-help)" >&2
-
-else
+  ;;
+*)
   command_path="$(command -v "rbenv-$command" || true)"
   if [ -z "$command_path" ]; then
     echo "rbenv: no such command \`$command'" >&2
@@ -31,4 +32,5 @@ else
 
   shift 1
   exec "$command_path" "$@"
-fi
+  ;;
+esac


### PR DESCRIPTION
First thing I did after installing was:

```
$ rbenv --help
rbenv: no such command `--help'
```

:-(

Added in attached commits.
