### PR TITLE
Get the executable gem dir from `gem environment` before rehash

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -25,7 +25,7 @@ rm -f *
 
 create_prototype_shim
 #make_shims ../versions/*/bin/*
-EXEC_GEM_DIR=$(rbenv exec gem environment | grep 'EXECUTABLE DIRECTORY' | sed -n 's/  - EXECUTABLE DIRECTORY: \(.*\)/\1/p')
+EXEC_GEM_DIR=$(rbenv exec gem environment | sed -n 's/  - EXECUTABLE DIRECTORY: \(.*\)/\1/p')
 make_shims $EXEC_GEM_DIR
 
 shopt -s nullglob


### PR DESCRIPTION
Hey,

I was having issues with running executable gems while set to rbx -- seemed that either:

A) rbenv was looking in the wrong directory to shim executables
B) gem for rubinius was installing executables incorrectly.

I went with setting rbenv's shimming directory to the one provided by `gem environment`.

I opened an issue before I looked into fixing it, see: https://github.com/sstephenson/rbenv/issues/36
