### PR TITLE
Instruct grep to not use color.

### DIFF
--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -2,7 +2,7 @@
 set -e
 
 read_version_file() {
-  egrep -m 1 '[^[:space:]]' "$1"
+  egrep --color=never -m 1 '[^[:space:]]' "$1"
 }
 
 DEFAULT_PATH="${HOME}/.rbenv/default"


### PR DESCRIPTION
Colors could be turned on via the GREP_OPTIONS environment variable,
in which case the read_version_file() function will return a colored
string, which won't be matched properly.
