### PR TITLE
Mention bundle exec when command not found

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -52,8 +52,10 @@ else
   versions="$(rbenv-whence "$RBENV_COMMAND" || true)"
   if [ -n "$versions" ]; then
     { echo
-      echo "The \`$1' command exists in these Ruby versions:"
+      echo "The \`$1\` command exists in these Ruby versions:"
       echo "$versions" | sed 's/^/  /g'
+      echo
+      echo "If you're using Bundler, try \`bundle exec\`"
       echo
     } >&2
   fi


### PR DESCRIPTION
No sweat if this is overkill, but I got tripped up when I was using Bundler and got a "command not found" message when running `rails console` and this kind of message would have helped me out. 
