### PR TITLE
Fix for system ruby when no global/default set (issue #62)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /versions
 /shims
 /default
+/global

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+GLOBAL_PATH="${HOME}/.rbenv/global"
+
 if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION_FILE="$(rbenv-version-file)"
-  RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
+  
+  if [ -e "$RBENV_VERSION_FILE" ]; then
+    RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
+  elif [ "$RBENV_VERSION_FILE" = "$GLOBAL_PATH" ]; then
+  	# Missing global file is equivalent to 'system'
+  	RBENV_VERSION="system"
+  fi
 fi
 
 if [ "$RBENV_VERSION" = "system" ]; then


### PR DESCRIPTION
- Make no global version file equivalent to system
- Ignore the global file in version control
