### PR TITLE
Support install locations other than $HOME/.rbenv.

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -19,6 +19,9 @@ abs_dirname() {
   cd "$cwd"
 }
 
+rbenv_install_location=$(abs_dirname "$(dirname $0)")
+export RBENV_HOME="${rbenv_install_location}"
+
 libexec_path="$(abs_dirname "$0")"
 export PATH="${libexec_path}:${PATH}"
 

--- a/libexec/rbenv-global
+++ b/libexec/rbenv-global
@@ -2,12 +2,12 @@
 set -e
 
 RBENV_VERSION="$1"
-RBENV_VERSION_FILE="${HOME}/.rbenv/global"
+RBENV_VERSION_FILE="${RBENV_HOME}/global"
 
 if [ -n "$RBENV_VERSION" ]; then
   rbenv-version-file-write "$RBENV_VERSION_FILE" "$RBENV_VERSION"
 else
   rbenv-version-file-read "$RBENV_VERSION_FILE" ||
-  rbenv-version-file-read "${HOME}/.rbenv/default" ||
+  rbenv-version-file-read "${RBENV_HOME}/default" ||
   echo system
 fi

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -55,9 +55,9 @@ if [ -z "$print" ]; then
   exit 1
 fi
 
-mkdir -p "${HOME}/.rbenv/"{shims,versions}
+mkdir -p "${RBENV_HOME}/"{shims,versions}
 
-echo 'export PATH="${HOME}/.rbenv/shims:${PATH}"'
+echo 'export PATH="'${RBENV_HOME}'/shims:${PATH}"'
 
 case "$shell" in
 bash | zsh )

--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -13,7 +13,7 @@ if [ "$RBENV_VERSION" = "system" ]; then
   exit
 fi
 
-RBENV_PREFIX_PATH="${HOME}/.rbenv/versions/${RBENV_VERSION}"
+RBENV_PREFIX_PATH="${RBENV_HOME}/versions/${RBENV_VERSION}"
 if [ ! -d "$RBENV_PREFIX_PATH" ]; then
   echo "rbenv: version \`${RBENV_VERSION}' not installed" >&2
   exit 1

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-SHIM_PATH="${HOME}/.rbenv/shims"
+SHIM_PATH="${RBENV_HOME}/shims"
 PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.rbenv-shim"
 
 # Create the shims directory if it doesn't already exist.
@@ -63,7 +63,7 @@ shopt -s nullglob
 make_shims ../versions/*/bin/*
 
 # Find and run any plugins that might want to make shims too.
-RBENV_REHASH_PLUGINS=(/etc/rbenv.d/rehash/*.bash ${HOME}/.rbenv/rbenv.d/rehash/*.bash)
+RBENV_REHASH_PLUGINS=(/etc/rbenv.d/rehash/*.bash ${RBENV_HOME}/rbenv.d/rehash/*.bash)
 shopt -u nullglob
 
 for script in ${RBENV_REHASH_PLUGINS[@]}; do

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -10,8 +10,8 @@ while [ -n "$root" ]; do
   root="${root%/*}"
 done
 
-GLOBAL_PATH="${HOME}/.rbenv/global"
-DEFAULT_PATH="${HOME}/.rbenv/default"
+GLOBAL_PATH="${RBENV_HOME}/global"
+DEFAULT_PATH="${RBENV_HOME}/default"
 
 if [ -e "$GLOBAL_PATH" ]; then
   echo "$GLOBAL_PATH"

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -11,7 +11,7 @@ if [ "$RBENV_VERSION" = "system" ]; then
   exit
 fi
 
-RBENV_VERSION_PATH="${HOME}/.rbenv/versions/${RBENV_VERSION}"
+RBENV_VERSION_PATH="${RBENV_HOME}/versions/${RBENV_VERSION}"
 
 if [ -d "$RBENV_VERSION_PATH" ]; then
   echo "$RBENV_VERSION"

--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -13,7 +13,7 @@ else
   print_version="$(rbenv-version)"
 fi
 
-for path in "${HOME}/.rbenv/versions/"*; do
+for path in "${RBENV_HOME}/versions/"*; do
   if [ -d "$path" ]; then
     version="${path##*/}"
 

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -30,14 +30,14 @@ RBENV_VERSION="$(rbenv-version-name)"
 RBENV_COMMAND="$1"
 
 if [ "$RBENV_VERSION" = "system" ]; then
-  PATH="$(remove_from_path "${HOME}/.rbenv/shims")"
+  PATH="$(remove_from_path "${RBENV_HOME}/shims")"
   RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND")"
 else
-  RBENV_COMMAND_PATH="${HOME}/.rbenv/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
+  RBENV_COMMAND_PATH="${RBENV_HOME}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi
 
 shopt -s nullglob
-RBENV_WHICH_PLUGINS=(/etc/rbenv.d/which/*.bash ${HOME}/.rbenv/rbenv.d/which/*.bash)
+RBENV_WHICH_PLUGINS=(/etc/rbenv.d/which/*.bash ${RBENV_HOME}/rbenv.d/which/*.bash)
 shopt -u nullglob
 
 for script in ${RBENV_WHICH_PLUGINS[@]}; do


### PR DESCRIPTION
Define RBENV_HOME env variable in libexec/rbenv and let all script delegates use this variable to determine rbenv's install location.
