### PR TITLE
rbenv global/local RUBY_PREFIX should work if there is a single match

### DIFF
--- a/libexec/rbenv-resolve
+++ b/libexec/rbenv-resolve
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+RBENV_VERSION="$1"
+
+if [ -z "$RBENV_VERSION" ]; then
+  echo "usage: rbenv resolve VERSION_PREFIX" >&2
+  exit 1
+fi
+
+system="system"
+if [ ${system#$RBENV_VERSION} != "system" ]; then
+  echo "system"
+  exit
+fi
+
+RBENV_PREFIX_PATH="${HOME}/.rbenv/versions/${RBENV_VERSION}"
+if [ -d "$RBENV_PREFIX_PATH" ]; then
+  echo $RBENV_VERSION
+  exit
+fi
+
+set +e
+POSSIBILITIES=(`ls -1d ${HOME}/.rbenv/versions/${RBENV_VERSION}* 2>/dev/null`)
+if [ $? != 0 ]; then
+  echo "rbenv: no matches for '$RBENV_VERSION'"
+  exit 1
+fi
+set -e
+
+if [ ${#POSSIBILITIES[@]} = 1 ]; then
+  echo `basename $POSSIBILITIES`
+else
+  echo "rbenv: more than one possible match for '$RBENV_VERSION': "
+  for var in "${POSSIBILITIES[@]}"; do
+    echo "  $(basename ${var})"
+  done
+  exit 1
+fi 

--- a/libexec/rbenv-version-file-write
+++ b/libexec/rbenv-version-file-write
@@ -9,6 +9,8 @@ if [ -z "$RBENV_VERSION" ] || [ -z "$RBENV_VERSION_FILE" ]; then
   exit 1
 fi
 
+RBENV_VERSION=`rbenv-resolve $RBENV_VERSION`
+
 # Make sure the specified version is installed.
 rbenv-prefix "$RBENV_VERSION" >/dev/null
 


### PR DESCRIPTION
ability for rbenv to resolve partial ruby names so it is not necessary to type the full version name everywhere

Adds rbenv-resolve that does the actual work, then the rest of the framework hooks into that when necessary.

```
# rbenv resolve 1.9
rbenv: more than one possible match for '1.9': 
  1.9.2-p290
  1.9.3-preview1
```

```
# rbenv resolve 1.9.2
1.9.2-p290
```

```
# rbenv local ree
# rbenv local
ree-1.8.7-2011.03
```
