### PR TITLE
Shims set RBENV_ROOT

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -37,6 +37,7 @@ create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
+export RBENV_ROOT="$RBENV_ROOT"
 exec rbenv exec "\${0##*/}" "\$@"
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"


### PR DESCRIPTION
Ensures shims are always callable even if `$HOME` or `$PATH` is screwed up. This can be the case with sudo which may or may not copy over shell vars.

Addresses #66
