### PR TITLE
Restore the current working directory in rbenv-rehash

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -55,6 +55,9 @@ make_shims() {
   done
 }
 
+# Save the working directory.
+CUR_PATH=$PWD
+
 # Empty out the shims directory and make it the working directory.
 rm -f "$SHIM_PATH"/*
 cd "$SHIM_PATH"
@@ -67,6 +70,9 @@ make_shims ../versions/*/bin/*
 # Find and run any plugins that might want to make shims too.
 RBENV_REHASH_PLUGINS=(/etc/rbenv.d/rehash/*.bash ${RBENV_ROOT}/rbenv.d/rehash/*.bash)
 shopt -u nullglob
+
+# Restore the previous working directory.
+cd "$CUR_PATH"
 
 for script in ${RBENV_REHASH_PLUGINS[@]}; do
   source $script


### PR DESCRIPTION
Recently I implemented an rbenv plugin that makes shims aware of executables in local, per-project bundle installation locations.  As of writing, currently

```
rbenv-{exec,rehash,which}
```

work.  Consequently, the user no longer has to type

```
bundle exec <command>
```

and

```
rbenv which <command>
```

will report bundled executables, if available.  You can check it out here: https://github.com/carsomyr/rbenv-bundler.

To get this all working, I've had to make a small change to `libexec/rbenv-rehash` which restores the current working directory after the default directories are searched.  This change enables plugins like mine to see the current working directory.  I'm wondering if this is a reasonable change, and if it can be included in the main repository.
