### PR TITLE
add symbol link support

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -2,14 +2,7 @@
 set -e
 
 expand_path() {
-  if [ ! -d "$1" ]; then
-    return 1
-  fi
-
-  local cwd="$(pwd)"
-  cd "$1"
-  pwd
-  cd "$cwd"
+	echo `readlink -f $1`
 }
 
 remove_from_path() {


### PR DESCRIPTION
allow two user share one ~/.rbenv

# user A: name: foo group: foo
   /home/foo/.rbenv

# user B: name: bar group: foo
   /home/bar/.rbenv -> /home/foo/.rbenv   # symlink to foo user

then, user B can use user A's rbenv now.
