### PR TITLE
Fix command to modify ~/.bash_profile in user's home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ easy to fork and contribute any changes back upstream.
 
 3. Add rbenv init to your shell to enable shims and autocompletion.
 
-        $ echo 'eval "$(rbenv init -)"' >> .bash_profile
+        $ echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 
     **Zsh note**: Modifiy your `~/.zshrc` file instead of `~/.bash_profile`.
 


### PR DESCRIPTION
Fix command to modify ~/.bash_profile in user's home directory (adding the ~/)
