### PR TITLE
rbenv-all

### DIFF
--- a/libexec/rbenv-all
+++ b/libexec/rbenv-all
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+bare=0
+
+if [ "$1" = "--bare" ]; then
+	bare=1
+	shift
+fi
+
+eval "$(rbenv init -)"
+
+original_version=$(rbenv shell 2>/dev/null)
+
+cleanup() {
+	if [ -n "$original_version" ]; then
+		rbenv shell $original_version
+	else
+		rbenv shell --unset
+	fi
+}
+trap cleanup 0
+
+for v in $(rbenv versions --bare); do
+	if [ "$bare" != "1" ]; then
+		echo "$v>> $*" 1>&2
+	fi
+	rbenv shell $v
+	$*
+	echo
+done
+


### PR DESCRIPTION
One of the reasons I use a ruby version manager is to easily test that my software works on multiple versions of ruby.

I'm using a wrapper called rbenv-all, which I use as follows:

$ rbenv all bundle exec rspec spec/
1.8.7-p352>> bundle exec rspec spec/
..............

Finished in 0.00497 seconds
14 examples, 0 failures

1.9.2-p290>> bundle exec rspec spec/
..............

Finished in 0.01258 seconds
14 examples, 0 failures

ree-1.8.7-2011.03>> bundle exec rspec spec/
..............

Finished in 0.00456 seconds
14 examples, 0 failures

I suspect that people who are developing jruby-only libraries would prefer to be able to specify exactly which rubies to use.  I haven't thought of an elegant way to handle that.
