### PR TITLE
Ensure RBENV_DIR is an absolute path only if it was absolute to begin with

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -45,11 +45,16 @@ for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
 done
 export PATH="${bin_path}:${PATH}"
 
-hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d"
-for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
-  hook_path="${hook_path}:${plugin_hook}"
-done
-export RBENV_HOOK_PATH="$hook_path"
+if [ -z "${_DEFINED_RBENV_HOOK_PATH}" ]; then
+
+  hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d"
+  for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
+    hook_path="${hook_path}:${plugin_hook}"
+  done
+  export RBENV_HOOK_PATH="$hook_path"
+
+  export _DEFINED_RBENV_HOOK_PATH="1"
+fi
 
 shopt -u nullglob
 


### PR DESCRIPTION
The recent rbenv updates are causing troubles for my `rbenv-bundler` plugin.  I've isolated the problem to the `abs_dirname` function, which is being (ab)used to convert relative pathnames to absolute ones.  Unfortunately, that means absolute pathnames like `RBENV_DIR=/a/b/c` get converted to `RBENV_DIR=/a/b`.  I also made a change that prevents sourcing plugins twice by only expanding `RBENV_HOOK_PATH` once.
