### PR TITLE
Quoting the argument to greadlink to make it work with paths containing spaces

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -3,7 +3,7 @@ set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) $1
+  $(type -p greadlink readlink | head -1) "$1"
 }
 
 abs_dirname() {


### PR DESCRIPTION
I had the following error message when starting a new shell:

```
/usr/local/bin/greadlink: extra operand `STL'
```

I believe the reason was that the current directory was named _Advanced STL_ (i.e. containing a space) which caused the call to `eval "$(rbenv init -)"` in my `.bashrc` file to fail.
