### PR TITLE
Made ksh portability changes

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -41,6 +41,9 @@ if [ -z "$print" ]; then
   zsh )
     profile='~/.zshrc'
     ;;
+  ksh )
+    profile='~/.profile'
+    ;;
   * )
     profile='your profile'
     ;;
@@ -71,7 +74,7 @@ echo 'rbenv rehash 2>/dev/null'
 commands=(`rbenv commands --sh`)
 IFS="|"
 cat <<EOS
-function rbenv() {
+function rbenv {
   command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift


### PR DESCRIPTION
Added specific message for ksh in identifying the proper shell
initialization file.

Changed rbenv functiond definition to be more portable.
Shell functions should be defined by using the function command or
using the parenthesis grammar, but using both is not portable:

rbenv() {...  -or-
function rbenv { ...
