### PR TITLE
Support system-installed plugins

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -43,13 +43,15 @@ export RBENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
-for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
+system_plugin_path="${bin_path}/../plugins"
+user_plugin_path="${RBENV_ROOT}/plugins"
+for plugin_bin in "${system_plugin_path}/"*/bin "${user_plugin_path}/"*/bin; do
   bin_path="${bin_path}:${plugin_bin}"
 done
 export PATH="${bin_path}:${PATH}"
 
 hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d"
-for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
+for plugin_hook in "${system_plugin_path}"/*/etc/rbenv.d "${user_plugin_path}/"*/etc/rbenv.d; do
   hook_path="${hook_path}:${plugin_hook}"
 done
 export RBENV_HOOK_PATH="$hook_path"


### PR DESCRIPTION
This helps for rbenv plugin packagers, for example, if rbenv main
programs are installed to /usr/lib/rbebv/libexec, then plugins can be
installed to /usr/lib/rbenv/plugins.

It also helps in development: I can create a plugins/ directory in rbenv
root and symlink the plugins I am testing there.
