### PR TITLE
Prevent $command from leaking outside of function

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -86,7 +86,7 @@ commands=(`rbenv commands --sh`)
 IFS="|"
 cat <<EOS
 rbenv() {
-  command="\$1"
+  local command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift
   fi


### PR DESCRIPTION
The `$command` variable currently sticks around after rbenv finishes executing, overwriting any previous value.

```
$ command=foo; echo $command; rbenv --help &> /dev/null; echo $command
foo
--help
```
