### PR TITLE
remove "+=" operator in rbenv-rehash to support bash-3.0

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -85,7 +85,7 @@ shim_variable_name() {
   if [[ ! "$shim" =~ [^[:alnum:]_-] ]]; then
     shim="${shim//_/_5f}"
     shim="${shim//-/_2d}"
-    result+="$shim"
+    result="$result$shim"
   else
     local length="${#shim}"
     local char i
@@ -93,9 +93,9 @@ shim_variable_name() {
     for ((i=0; i<length; i++)); do
       char="${shim:$i:1}"
       if [[ "$char" =~ [[:alnum:]] ]]; then
-        result+="$char"
+        result="$result$char"
       else
-        result+="$(printf "_%02x" \'"$char")"
+        result="$result$(printf "_%02x" \'"$char")"
       fi
     done
   fi


### PR DESCRIPTION
The "+=" operator was added in bash-3.1-alpha1. 
Could you consider remove it to support older bash versions?

http://lists.gnu.org/archive/html/info-gnu/2005-12/msg00003.html
