### PR TITLE
Autodetect right value for RBENV_ROOT

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -21,7 +21,8 @@ abs_dirname() {
 }
 
 if [ -z "${RBENV_ROOT}" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
+  RBENV_ROOT=`dirname "$0"`
+  RBENV_ROOT=`cd "$RBENV_ROOT/.."; pwd`
 else
   RBENV_ROOT="${RBENV_ROOT%/}"
 fi


### PR DESCRIPTION
If RBENV_ROOT is not set, it will be set to rbenv's own directory instead of to ~/.rbenv. This makes it unnecessary to manually set RBENV_ROOT in most cases.
