### PR TITLE
Fixed broken link to RVM in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ tools that do one thing well.
     [rbenv-gemset](https://github.com/jamis/rbenv-gemset) plugin.
 * **Require changes to Ruby libraries for compatibility.** The
     simplicity of rbenv means as long as it's in your `$PATH`,
-    [nothing](https://rvm.beginrescueend.com/integration/bundler/)
-    [else](https://rvm.beginrescueend.com/integration/capistrano/)
+    [nothing](https://rvm.io/integration/bundler/)
+    [else](https://rvm.io/integration/capistrano/)
     needs to know about it.
 * **Prompt you with warnings when you switch to a project.** Instead
     of executing arbitrary code, rbenv reads just the version name

--- a/doc/README.mdtoc
+++ b/doc/README.mdtoc
@@ -30,8 +30,8 @@ tools that do one thing well.
     [rbenv-gemset](https://github.com/jamis/rbenv-gemset) plugin.
 * **Require changes to Ruby libraries for compatibility.** The
     simplicity of rbenv means as long as it's in your `$PATH`,
-    [nothing](https://rvm.beginrescueend.com/integration/bundler/)
-    [else](https://rvm.beginrescueend.com/integration/capistrano/)
+    [nothing](https://rvm.io/integration/bundler/)
+    [else](https://rvm.io/integration/capistrano/)
     needs to know about it.
 * **Prompt you with warnings when you switch to a project.** Instead
     of executing arbitrary code, rbenv reads just the version name


### PR DESCRIPTION
Since the beginning of April RVM has a new domain name: rvm.io (https://twitter.com/#!/wayneeseguin/status/188634745079468032)

https://rvm.beginrescueend.com is broken because it serves a self-signed certificate (http://rvm.beginrescueend.com redirects to https://rvm.io though).
