### PR TITLE
avoid process substitution 

### DIFF
--- a/libexec/rbenv-version-file-read
+++ b/libexec/rbenv-version-file-read
@@ -8,12 +8,12 @@ if [ -e "$VERSION_FILE" ]; then
   # Read and print the first non-whitespace word from the specified
   # version file.
   version=""
-  while read -a words; do
+  ( cat "$VERSION_FILE" && echo ) | while read -a words; do
     word="${words[0]}"
     if [ -z "$version" ] && [ -n "$word" ]; then
       version="$word"
     fi
-  done < <( cat "$VERSION_FILE" && echo )
+  done
 
   if [ -n "$version" ]; then
     echo "$version"


### PR DESCRIPTION
It might not be supported by a lot of shells. This is the only occurence
of process substitution in this project, and the issue #222 ([1])
mentions a strange syntax error in this file.

[1] https://github.com/sstephenson/rbenv/issues/222
