### PR TITLE
Allow processing to continue in rbenv-which when command isn't found with system Ruby

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -50,7 +50,7 @@ fi
 
 if [ "$RBENV_VERSION" = "system" ]; then
   PATH="$(remove_from_path "${RBENV_ROOT}/shims")"
-  RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND")"
+  RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
 else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi


### PR DESCRIPTION
When it detects the system Ruby, `rbenv-which` attempts to run `$(command -v "$RBENV_COMMAND")`, and this leads the script to [exit prematurely](https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-which#L53) because of a combination of a nonzero return value and the Bash mode `set -e`. I propose to mask the return value and leave the final checking to [later lines](https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-which#L62-77). Doing so leads to the expected behavior.

```
$ rbenv which blah
  rbenv: blah: command not found
```

Without the patch, rbenv is totally silent. The patch also allows [my plugin](https://github.com/carsomyr/rbenv-bundler) to work correctly.
