### PR TITLE
Fix zsh rbenv.bash problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ easy to fork and contribute any changes back upstream.
 
         $ echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 
-    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    **Zsh note**: Run `$ echo 'eval "$(rbenv init -zsh)"' >> ~/.zshenv`
 
 4. Restart your shell so the path changes take effect. You can now
    begin using rbenv.


### PR DESCRIPTION
This changes get rid of the error:

    /home/helex/.rbenv/libexec/../completions/rbenv.bash:14: command not found: complete

when opening a new shell.
