### PR TITLE
Speed up rbenv-init by finding shell commands inline

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -82,7 +82,15 @@ if [ -z "$no_rehash" ]; then
   echo 'rbenv rehash 2>/dev/null'
 fi
 
-commands=(`rbenv commands --sh`)
+shell_commands=()
+shopt -s nullglob
+{ for path in ${PATH//:/$'\n'}; do
+    for command in "${path}/rbenv-sh-"*; do
+      shell_commands+=(${command##*rbenv-sh-})
+    done
+  done
+}
+
 IFS="|"
 cat <<EOS
 rbenv() {
@@ -92,7 +100,7 @@ rbenv() {
   fi
 
   case "\$command" in
-  ${commands[*]})
+  ${shell_commands[*]})
     eval \`rbenv "sh-\$command" "\$@"\`;;
   *)
     command rbenv "\$command" "\$@";;


### PR DESCRIPTION
**Problem**
`rbenv init -` is rather slow, which is an issue since it is used in shell startup scripts.
One of the causes is that inside `rbenv-init`, another call to `rbenv` is made:

```
commands=(`rbenv commands --sh`)
```

This makes the `rbenv init` command carry the rbenv startup overhead _twice_:
once for `init` itself, and once for `commands`.

**Proposed solution**
I have created a function inside `rbenv-init` that finds shell commands,
after an [earlier solution that hard-coded the commands](https://github.com/sstephenson/rbenv/pull/253) had [proven insufficient](https://github.com/sstephenson/rbenv/pull/253#issuecomment-7682615).

**Result**
On my system, execution times improved from

```
real    0m0.069s
user    0m0.022s
sys     0m0.047s
```

to

```
real    0m0.042s
user    0m0.012s
sys     0m0.029s
```

which is a 40% decrease.
