### PR TITLE
Speed up rbenv-init by using rbenv-commands.

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -82,7 +82,7 @@ if [ -z "$no_rehash" ]; then
   echo 'rbenv rehash 2>/dev/null'
 fi
 
-commands=(`rbenv commands --sh`)
+commands=(`rbenv-commands --sh`)
 IFS="|"
 cat <<EOS
 rbenv() {


### PR DESCRIPTION
As suggested [here](https://github.com/sstephenson/rbenv/pull/254#issuecomment-7697896),
this speeds up `rbenv-init` by calling `rbenv-commands` directly.
