### PR TITLE
Base RBENV_ROOT default on path of invoked binary

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -21,7 +21,7 @@ abs_dirname() {
 }
 
 if [ -z "${RBENV_ROOT}" ]; then
-  RBENV_ROOT="${HOME}/.rbenv"
+  RBENV_ROOT="${0%/*/rbenv}"
 else
   RBENV_ROOT="${RBENV_ROOT%/}"
 fi


### PR DESCRIPTION
Instead of naievely assuming that it's installed to $HOME/.rbenv
