### PR TITLE
Updated rbenv install instructions for ZSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ easy to fork and contribute any changes back upstream.
 
         $ echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 
-    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile`.
+    **Zsh note**: Modify your `~/.zshenv` file instead of `~/.bash_profile` as follows:
+    
+        $ echo 'eval "$(rbenv init - zsh)"' >> ~/.zshenv
 
 4. Restart your shell so the path changes take effect. You can now
    begin using rbenv.


### PR DESCRIPTION
It wasn't clear from the README that you could pass an argument to the `rbenv init` command.

This commit clarifies that information and adds additional installation instructions for ZSH users.
