### PR TITLE
Support for completion of full command line

### DIFF
--- a/completions/rbenv.bash
+++ b/completions/rbenv.bash
@@ -5,8 +5,10 @@ _rbenv() {
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "$(rbenv commands)" -- "$word") )
   else
-    local command="${COMP_WORDS[1]}"
-    local completions="$(rbenv completions "$command")"
+    local words=("${COMP_WORDS[@]}")
+    unset words[0]
+    unset words[$COMP_CWORD]
+    local completions=$(rbenv completions "${words[@]}")
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
   fi
 }


### PR DESCRIPTION
Currently only the first word is used in the subcommand autocompletion. 

This pull request changes that so that now all but the current word in the command being completed is sent to `rbenv completions` which already correctly sends them on to the subcommand.

Note: The change is only done for bash so someone else will have to do it for zsh.
