### PR TITLE
Added version mode flag

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -64,7 +64,7 @@ case "$command" in
 "" | "-h" | "--help" )
   echo -e "rbenv $RBENV_PROJECT_VERSION\n$(rbenv-help)" >&2
   ;;
-"" | "-v" | "--version" )
+"" | "-V" | "--version" )
   echo -e "rbenv $RBENV_PROJECT_VERSION\n" >&2
   ;;
 * )


### PR DESCRIPTION
I noted that `rbenv` didn't have a `version` mode flag, hence this pull request.
- Added variable for project version
- Updated help mode flag to use project version variable
- Added version mode flag
