### PR TITLE
fix `versions` in case current version doesn't exist

### DIFF
--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -2,24 +2,22 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-RBENV_VERSION_NAME="$(rbenv-version-name)"
-
 if [ "$1" = "--bare" ]; then
   hit_prefix=""
   miss_prefix=""
-  print_version="$RBENV_VERSION_NAME"
+  current_version=""
 else
   hit_prefix="* "
   miss_prefix="  "
-  print_version="$(rbenv-version)"
+  current_version="$(rbenv-version-name || true)"
 fi
 
 for path in "${RBENV_ROOT}/versions/"*; do
   if [ -d "$path" ]; then
     version="${path##*/}"
 
-    if [ "$version" == "$RBENV_VERSION_NAME" ]; then
-      echo "${hit_prefix}${print_version}"
+    if [ "$version" == "$current_version" ]; then
+      echo "${hit_prefix}$(rbenv-version)"
     else
       echo "${miss_prefix}${version}"
     fi


### PR DESCRIPTION
`rbenv-versions` tries to read the current version to display a marker
next to it, but if that fails the whole script aborts.

This change makes it so that the failures from `rbenv-version-name` are
tolerated. It also makes the `--bare` mode never call it in the first
place, because it doesn't need to display a marker.
