### PR TITLE
Fix the reference to `rbenv shell` and make it `rbenv sh-shell` instead.

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -25,7 +25,7 @@ Some useful rbenv commands are:
    rehash        Rehash rbenv shims (run this after installing binaries)
    global        Set or show the global Ruby version
    local         Set or show the local directory-specific Ruby version
-   shell         Set or show the shell-specific Ruby version
+   sh-shell      Set or show the shell-specific Ruby version
    version       Show the current Ruby version
    versions      List all Ruby versions known by rbenv
    which         Show the full path for the given Ruby command


### PR DESCRIPTION
A number of my colleagues and I were somewhat perplexed by the recent non-existence of the 'shell' command, only to find that it was now actually 'sh-shell'. This updates the output of `rbenv help` to reflect the change.
