### PR TITLE
Can't run rbenv-commands unless PATH contains /usr/local/rbenv/libexec

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -82,7 +82,7 @@ if [ -z "$no_rehash" ]; then
   echo 'rbenv rehash 2>/dev/null'
 fi
 
-commands=(`rbenv-commands --sh`)
+commands=(`rbenv commands --sh`)
 IFS="|"
 cat <<EOS
 rbenv() {


### PR DESCRIPTION
Reverted change. The PATH might not contain /usr/local/rbenv/libexec! Such as when installing Rbenv on a clean machine. 

Using `rbenv commands` rather than `rbenv-commands` fixes it.
