### PR TITLE
Fix incorrect formatting of rbenv-help output under MAWK

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -64,8 +64,8 @@ collect_documentation() {
     }
 
     function trim(str) {
-      gsub(/^\n*/, "", str)
-      gsub(/\n*$/, "", str)
+      sub(/^\n*/, "", str)
+      sub(/\n*$/, "", str)
       return str
     }
 


### PR DESCRIPTION
In systems that use the MAWK interpreter (the default AWK installed with Ubuntu), the output of `rbenv help <command>` is stripped of all its line breaks. For example:

```
$ rbenv help local
Usage: rbenv local <version>       rbenv local --unset

Sets the local application-specific Ruby version by writing theversion name to a file named `.ruby-version'.When you run a Ruby command, rbenv will look for a `.ruby-version'file in the current directory and each parent directory. If no suchfile is found in the tree, rbenv will use the global Ruby versionspecified with `rbenv global'. A version specified with the`RBENV_VERSION' environment variable takes precedence over localand global versions.For backwards compatibility, rbenv will also read versionspecifications from `.rbenv-version' files, but a `.ruby-version'file in the same directory takes precedence.<version> should be a string matching a Ruby version known to rbenv.The special version string `system' will use your default system Ruby.Run `rbenv versions' for a list of available Ruby versions.
```

The issue is fixed by changing `gsub` to `sub` in the snippet of AWK commands that are used to extract documentation comments in `rbenv-help`.

I suspect the bug is something to do with the way the `^` and `$` characters are handled by different AWK interpreters (per-line vs per-string anchors).

If I understand correctly, the purpose of `trim()` is to remove all line breaks from the start and end of each sections of a command's documentation, in which case `sub` should serve the same purpose as `gsub`.
