### PR TITLE
Ignoring Your Sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /shims
 /version
 /versions
+/sources


### PR DESCRIPTION
> The story begins in the dark, dark night. The night after the [Qualcomm](http://www.theverge.com/2013/1/8/3850056/qualcomms-insane-ces-2013-keynote-pictures-tweets) attack upon the world.

The console was like this yo.

```
jalcine: Oy, `rbenv` isn't ignoring `./sources`.
git: Aye.
jalcine: So ignore it.
git: Aye.
```

And it was done.
On a serious note, this pull requests adds `/sources` to Git ignores so that we can ignore our personal copies of mruby, ree, and jruby. With pleasure. :hamburger: 
