### PR TITLE
`rbenv env` command for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ RVM?**](https://github.com/sstephenson/rbenv/wiki/Why-rbenv%3F)
   * [Neckbeard Configuration](#neckbeard-configuration)
   * [Uninstalling Ruby Versions](#uninstalling-ruby-versions)
 * [Command Reference](#command-reference)
+  * [rbenv env](#rbenv-env)
   * [rbenv local](#rbenv-local)
   * [rbenv global](#rbenv-global)
   * [rbenv shell](#rbenv-shell)
@@ -290,6 +291,13 @@ process.
 
 Like `git`, the `rbenv` command delegates to subcommands based on its
 first argument. The most common subcommands are:
+
+### rbenv env
+
+Shows pertinent environment variables that are set by shims or rbenv exec
+(specifically PATH environment variable as well as any variables that start with GEM or RBENV)
+
+    $ rbenv env
 
 ### rbenv local
 

--- a/libexec/rbenv-env
+++ b/libexec/rbenv-env
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Summary: Run an executable with the selected Ruby version
+#
+# Usage: rbenv exec <command> [arg1 arg2...]
+#
+# Runs an executable by first preparing PATH so that the selected Ruby
+# version's `bin' directory is at the front.
+#
+# For example, if the currently selected Ruby version is 1.9.3-p327:
+#   rbenv exec bundle install
+#
+# is equivalent to:
+#   PATH="$RBENV_ROOT/versions/1.9.3-p327/bin:$PATH" bundle install
+
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+export RBENV_VERSION="$(rbenv-version-name)"
+
+for script in $(rbenv-hooks exec); do
+  source "$script"
+done
+
+RBENV_COMMAND="ruby"
+
+RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
+RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
+
+if [ "$RBENV_VERSION" != "system" ]; then
+  export PATH="${RBENV_BIN_PATH}:${PATH}"
+fi
+
+/usr/bin/env | egrep '^GEM|^RBENV|^PATH='


### PR DESCRIPTION
Please pull new 'rbenv env' command (shows PATH, GEM\* and RBENV\* environment variables).

I added this to help understand rbenv and the gemset plugin. I feel it would also be useful for debugging and generally an understanding of what is happening when things don't go as expected.
