### PR TITLE
rbenv(): preserve newlines in outputs

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -97,7 +97,7 @@ rbenv() {
 
   case "\$command" in
   ${commands[*]})
-    eval \`rbenv "sh-\$command" "\$@"\`;;
+    eval "\`rbenv "sh-\$command" "\$@"\`";;
   *)
     command rbenv "\$command" "\$@";;
   esac


### PR DESCRIPTION
When a sh-\* command is called, newlines in the outputs of the command cannot be preserved, resulting in that the commands in the outputs would not be executed correctly. For example, the outputs of the sh-\* command is:

```
# comment
echo 'hi'
```

`eval` of line 100 in rbenv-init will get a string like this:

```
# comment echo 'hi'
```

The command `echo` will not be executed in this case.

Please check this.
