### PR TITLE
Fix multiple argument completion with zsh

### DIFF
--- a/completions/rbenv.zsh
+++ b/completions/rbenv.zsh
@@ -11,7 +11,7 @@ _rbenv() {
   if [ "${#words}" -eq 2 ]; then
     completions="$(rbenv commands)"
   else
-    completions="$(rbenv completions ${words[2,-1]})"
+    completions="$(rbenv completions ${words[2,-2]})"
   fi
 
   reply=("${(ps:\n:)completions}")


### PR DESCRIPTION
This changes the zsh completion to omit the final, incomplete command line argument when invoking rbenv completions, making it consistent with the bash completion.  Since no built-in completion cares about the argument list, this inconsistency only affected plugins.
