### PR TITLE
Don't duplicate shims in PATH

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -73,7 +73,9 @@ fi
 
 mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
-echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+if [[ ":${PATH}:" != *:"${RBENV_ROOT}/shims":* ]]; then
+  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+fi
 
 case "$shell" in
 bash | zsh )


### PR DESCRIPTION
If you're loading rbenv in `.bashrc` or `.zshrc`, the shims path can potentially become duplicated over and over again in `$PATH` as you spawn subshells. This patch guards against that.

This is also helpful if you (like me) like to micromanage the order of `$PATH`.
