### PR TITLE
Add ability to specify ruby version for rbenv exec

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -2,7 +2,7 @@
 #
 # Summary: Run an executable with the selected Ruby version
 #
-# Usage: rbenv exec <command> [arg1 arg2...]
+# Usage: rbenv exec [--ruby VERSION] <command> [arg1 arg2...]
 #
 # Runs an executable by first preparing PATH so that the selected Ruby
 # version's `bin' directory is at the front.
@@ -12,6 +12,9 @@
 #
 # is equivalent to:
 #   PATH="$RBENV_ROOT/versions/1.9.3-p327/bin:$PATH" bundle install
+#
+# You may also override the path that would otherwise be selected by
+# specifying a Ruby version on which to operate with the --ruby flag.
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
@@ -21,8 +24,15 @@ if [ "$1" = "--complete" ]; then
   exec rbenv shims --short
 fi
 
-export RBENV_VERSION="$(rbenv-version-name)"
-RBENV_COMMAND="$1"
+# Provide ability to specify which Ruby
+if [ "$1" = "--ruby" ]; then
+  export RBENV_VERSION="$2"
+  RBENV_COMMAND="$3"
+  shift 2
+else
+  export RBENV_VERSION="$(rbenv-version-name)"
+  RBENV_COMMAND="$1"
+fi
 
 if [ -z "$RBENV_COMMAND" ]; then
   rbenv-help --usage exec >&2
@@ -40,4 +50,5 @@ shift 1
 if [ "$RBENV_VERSION" != "system" ]; then
   export PATH="${RBENV_BIN_PATH}:${PATH}"
 fi
+
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
I added an additional flag and parameter to allow a user to choose the Ruby to use during an `rbenv exec` invocation.

My original motivation was, before installing the heroku toolbelt, checking to ensure I had no gem installed for the Ruby I was working in.  Turns out I did not, but I had some other ones that I also wanted to remove without having to track down which projects were using those Ruby versions.

Another nice possibility is being able to bring up an `irb` console (or what have you) without having to navigate through the directory structure in order to switch to that Ruby.

Please let me know if you would like me to make any changes to this pull request or if you would have done something differently.  I do hope you like the new feature and also consider it useful.
