### PR TITLE
allow non-bash scripts to provide tab completions

### DIFF
--- a/libexec/rbenv-completions
+++ b/libexec/rbenv-completions
@@ -11,7 +11,7 @@ if [ -z "$COMMAND" ]; then
 fi
 
 COMMAND_PATH="$(command -v "rbenv-$COMMAND" || command -v "rbenv-sh-$COMMAND")"
-if grep -i "^# provide rbenv completions" "$COMMAND_PATH" >/dev/null; then
+if grep -i "^\([#%]\|--\|//\) provide rbenv completions" "$COMMAND_PATH" >/dev/null; then
   shift
   exec "$COMMAND_PATH" --complete "$@"
 fi


### PR DESCRIPTION
change grep based comment matching to detect completions to test
that a subcommand responds to `--complete' to allow scripts where
comments are of an incompatible format to provide tab completions
