### PR TITLE
Change `exec` semantics to allow using rbenv from a ruby process

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -2,24 +2,59 @@
 #
 # Summary: Run an executable with the selected Ruby version
 #
-# Usage: rbenv exec <command> [arg1 arg2...]
+# Usage: rbenv exec <command> [args...]
 #
-# Runs an executable by first preparing PATH so that the selected Ruby
-# version's `bin' directory is at the front.
+# Runs an executable contained by the currently selected Ruby's bin
+# directory. Rough equivalent of:
 #
-# For example, if the currently selected Ruby version is 1.9.3-p327:
-#   rbenv exec bundle install
-#
-# is equivalent to:
-#   PATH="$RBENV_ROOT/versions/1.9.3-p327/bin:$PATH" bundle install
+#   exec "$(rbenv prefix)/bin/$command" args...
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+rubypath=""
 # Provide rbenv completions
-if [ "$1" = "--complete" ]; then
-  exec rbenv shims --short
-fi
+while true; do
+  case "$1" in
+  "--complete" )
+    exec rbenv shims --short
+    ;;
+  "--rubypath" )
+    rubypath=1
+    shift 1
+    ;;
+  * )
+    break
+    ;;
+  esac
+done
+
+# Replace any "RBENV_ROOT/shims" or "RBENV_ROOT/versions/*/bin" paths in the
+# list with the given path. If no replacements were made, prepend the path onto
+# the list.
+replace_shims_path() {
+  local path="$1"
+  local dir="$2"
+  # fake directory that serves as a placeholder for shims location in RUBYPATH:
+  local placeholder="/rbenv_shims_were_here"
+  local found=""
+  local result=""
+  local -a paths
+  IFS=: paths=($path)
+
+  for path in "${paths[@]}"; do
+    if [[ $path = "${RBENV_ROOT}/shims" || $path == "${RBENV_ROOT}/versions/"*/bin || $path = $placeholder ]]; then
+      found=1
+      result="${result}${dir:-$placeholder}:"
+    else
+      result="${result}${path}:"
+    fi
+  done
+
+  # if no rbenv paths were replaced, simply prepend the path
+  [ -n "$found" -o -z "$dir" ] || result="${dir}:${path}"
+  echo "${result%:}"
+}
 
 RBENV_VERSION="$(rbenv-version-name)"
 RBENV_COMMAND="$1"
@@ -31,7 +66,6 @@ fi
 
 export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
-RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks exec`)
@@ -41,7 +75,9 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-if [ "$RBENV_VERSION" != "system" ]; then
-  export PATH="${RBENV_BIN_PATH}:${PATH}"
+if [ -n "$rubypath" ]; then
+  bindir=""
+  [ "$RBENV_VERSION" != "system" ] && bindir="${RBENV_COMMAND_PATH%/*}"
+  export RUBYPATH="$(replace_shims_path "${RUBYPATH:-$PATH}" "$bindir")"
 fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -45,10 +45,12 @@ create_prototype_shim() {
 set -e
 [ -n "\$RBENV_DEBUG" ] && set -x
 
+opt=""
 program="\${0##*/}"
 if [ "\$program" = "ruby" ]; then
   for arg; do
     case "\$arg" in
+    -S* ) opt=--rubypath ;;
     -e* | -- ) break ;;
     */* )
       if [ -f "\$arg" ]; then
@@ -61,7 +63,7 @@ if [ "\$program" = "ruby" ]; then
 fi
 
 export RBENV_ROOT="$RBENV_ROOT"
-exec "$(command -v rbenv)" exec "\$program" "\$@"
+exec "$(command -v rbenv)" exec \$opt "\$program" "\$@"
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"
 }

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -3,15 +3,37 @@
 load test_helper
 
 create_executable() {
-  name="${1?}"
+  local file="${1?}"
+  [[ $file == */* ]] || file="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/$file"
   shift 1
-  bin="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin"
-  mkdir -p "$bin"
+  mkdir -p "${file%/*}"
   { if [ $# -eq 0 ]; then cat -
     else echo "$@"
     fi
-  } | sed -Ee '1s/^ +//' > "${bin}/$name"
-  chmod +x "${bin}/$name"
+  } | sed -Ee '1s/^[[:space:]]+//' > "$file"
+  chmod +x "$file"
+}
+
+# Fake ruby executable that emulates `ruby -S <cmd>' behavior by running the
+# first `cmd' found in RUBYPATH/PATH as bash script.
+create_ruby_executable() {
+  create_executable "${1:-ruby}" <<SH
+#!$BASH
+if [[ \$1 == "-S"* ]]; then
+  cmd="\${1#-S}"
+  [ -n "\$cmd" ] || cmd="\$2"
+  found="\$(PATH="\${RUBYPATH:-\$PATH}" \$(command -v which) \$cmd)"
+  # assert that the found executable has ruby for shebang
+  if head -1 "\$found" | grep ruby >/dev/null; then
+    \$BASH "\$found"
+  else
+    echo "ruby: no Ruby script found in input (LoadError)" >&2
+    exit 1
+  fi
+else
+  echo 'ruby (rbenv test)'
+fi
+SH
 }
 
 @test "fails with invalid version" {
@@ -82,26 +104,56 @@ ${RBENV_ROOT}/versions/2.0/bin/ruby
 OUT
 }
 
+@test "doesn't mutate PATH" {
+  export RBENV_VERSION="2.0"
+  create_executable "ruby" <<SH
+#!$BASH
+echo \$PATH
+SH
+
+  run rbenv-exec ruby
+  assert_success "$PATH"
+}
+
+@test "doesn't set RUBYPATH" {
+  export RBENV_VERSION="2.0"
+  create_executable "ruby" <<SH
+#!$BASH
+echo \$RUBYPATH
+SH
+
+  RUBYPATH="" run rbenv-exec ruby
+  assert_success
+  assert_output ""
+}
+
+@test "allows subprocesses to select a different RBENV_VERSION" {
+  RBENV_VERSION=1.8 create_executable "rake" <<SH
+#!$BASH
+echo rake 1.8
+SH
+
+  export RBENV_VERSION="2.0"
+  create_executable "rake" "#!/bin/sh"
+  create_executable "ruby" <<SH
+#!$BASH
+echo ruby 2.0
+RBENV_VERSION=1.8 exec rake
+SH
+
+  rbenv rehash
+  run ruby
+  assert_success
+  assert_output <<OUT
+ruby 2.0
+rake 1.8
+OUT
+}
+
 @test "supports ruby -S <cmd>" {
   export RBENV_VERSION="2.0"
 
-  # emulate `ruby -S' behavior
-  create_executable "ruby" <<SH
-#!$BASH
-if [[ \$1 == "-S"* ]]; then
-  found="\$(PATH="\${RUBYPATH:-\$PATH}" which \$2)"
-  # assert that the found executable has ruby for shebang
-  if head -1 "\$found" | grep ruby >/dev/null; then
-    \$BASH "\$found"
-  else
-    echo "ruby: no Ruby script found in input (LoadError)" >&2
-    exit 1
-  fi
-else
-  echo 'ruby 2.0 (rbenv test)'
-fi
-SH
-
+  create_ruby_executable
   create_executable "rake" <<SH
 #!/usr/bin/env ruby
 echo hello rake
@@ -110,4 +162,152 @@ SH
   rbenv-rehash
   run ruby -S rake
   assert_success "hello rake"
+}
+
+@test "supports ruby -S with system version" {
+  export RBENV_VERSION=2.0
+  create_executable "ruby" "#!/bin/sh"
+  create_executable "rake" "#!/bin/sh"
+  rbenv-rehash
+
+  create_ruby_executable "${RBENV_TEST_DIR}/bin/ruby"
+  create_executable "${RBENV_TEST_DIR}/bin/rake" <<SH
+#!/usr/bin/env ruby
+echo system rake
+SH
+
+  RBENV_VERSION=system run ruby -S rake
+  assert_success "system rake"
+}
+
+@test "ruby -S allows commands higher in PATH to have precedence over shims" {
+  export RBENV_VERSION="2.0"
+
+  create_ruby_executable
+  create_executable "rake" <<SH
+#!/usr/bin/env ruby
+echo normal rake
+SH
+  rbenv-rehash
+
+  create_executable "${HOME}/bin/rake" <<SH
+#!/usr/bin/env ruby
+echo override rake
+SH
+
+  PATH="${HOME}/bin:$PATH" run ruby -S rake
+  assert_success "override rake"
+}
+
+@test "ruby -S respects existing RUBYPATH" {
+  export RBENV_VERSION="2.0"
+
+  create_ruby_executable
+  create_executable "rspec" <<SH
+#!/usr/bin/env ruby
+echo normal rspec
+SH
+  rbenv-rehash
+
+  create_executable "${HOME}/bin/rspec" "#!/bin/sh"
+  create_executable "${HOME}/bin/rake" <<SH
+#!/usr/bin/env ruby
+echo override rake
+SH
+
+  export RUBYPATH="${HOME}/bin"
+  run ruby -S rspec
+  assert_success "normal rspec"
+  run ruby -S rake
+  assert_success "override rake"
+}
+
+@test "supports nested ruby -S invocations to change RBENV_VERSION" {
+  export RBENV_VERSION="1.8"
+  create_ruby_executable
+  create_executable "rspec" <<SH
+#!/usr/bin/env ruby
+echo rspec 1.8
+SH
+
+  export RBENV_VERSION="2.0"
+  create_ruby_executable
+  create_executable "rspec" <<SH
+#!/usr/bin/env ruby
+echo rspec 2.0
+SH
+  create_executable "rake" <<SH
+#!/usr/bin/env ruby
+echo rake 2.0
+RBENV_VERSION=1.8 ruby -S rspec
+SH
+
+  rbenv-rehash
+  run ruby -S rake
+  assert_success
+  assert_output <<OUT
+rake 2.0
+rspec 1.8
+OUT
+}
+
+@test "supports system ruby -S invocation to select a different RBENV_VERSION" {
+  export RBENV_VERSION="2.0"
+  create_ruby_executable
+  create_executable "rspec" <<SH
+#!/usr/bin/env ruby
+echo rspec 2.0
+SH
+  rbenv-rehash
+
+  create_ruby_executable "${RBENV_TEST_DIR}/bin/ruby"
+  create_executable "${RBENV_TEST_DIR}/bin/rspec" <<SH
+#!/usr/bin/env ruby
+echo system rspec
+SH
+  create_executable "${RBENV_TEST_DIR}/bin/rake" <<SH
+#!/usr/bin/env ruby
+echo system rake
+RBENV_VERSION=2.0 ruby -S rspec
+SH
+
+  RBENV_VERSION=system run ruby -S rake
+  assert_success
+  assert_output <<OUT
+system rake
+rspec 2.0
+OUT
+}
+
+@test "nested ruby -S invocations preserve PATH precedence" {
+  export RBENV_VERSION="2.0"
+  create_ruby_executable
+  create_executable "rspec" <<SH
+#!/usr/bin/env ruby
+echo rspec 2.0
+SH
+  rbenv-rehash
+
+  create_ruby_executable "${RBENV_TEST_DIR}/bin/ruby"
+  create_executable "${RBENV_TEST_DIR}/bin/rspec" <<SH
+#!/usr/bin/env ruby
+echo system rspec
+SH
+  create_executable "${RBENV_TEST_DIR}/bin/rake" <<SH
+#!/usr/bin/env ruby
+echo system rake
+RBENV_VERSION=2.0 ruby -S rspec
+SH
+
+  create_executable "${HOME}/bin/rspec" <<SH
+#!/usr/bin/env ruby
+echo override rspec
+SH
+
+  PATH="${HOME}/bin:$PATH" RBENV_VERSION=system run ruby -S rake
+  assert_success
+  assert_output <<OUT
+system rake
+override rspec
+OUT
 }


### PR DESCRIPTION
The most common pitfall with rbenv is that you can't shell out to another rbenv version from a ruby process started with rbenv. #121

This is an unfortunate side-effect of a PATH-modifying hack to allow support for `ruby -S`. #14

Here I propose that we stop modifying PATH during `rbenv-exec` unless we're actually dealing with `ruby -S`.

The drawback of this change is that you still can't shell out to another rbenv version from a process started with `ruby -S`. An alternative solution to this change would be to re-implement the `ruby -S` semantics and execute it without ever needing to change PATH.
