### PR TITLE
Need for ~/.rbenvrc

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -12,6 +12,10 @@ if [ -n "$RBENV_DEBUG" ]; then
   set -x
 fi
 
+if [ -f "${HOME}/.rbenvrc" ]; then
+  source "${HOME}/.rbenvrc"
+fi
+
 resolve_link() {
   $(type -p greadlink readlink | head -1) "$1"
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -45,3 +45,11 @@ load test_helper
   assert_failure
   assert_output "rbenv: cannot change working directory to \`$dir'"
 }
+
+@test "runs commands from ~/.rbenvrc" {
+  mkdir -p "${BATS_TMPDIR}/home/raven"
+  echo "export ONCE_UPON_A_MIDNIGHT_DREARY='while I pondered weak and weary'" > "${BATS_TMPDIR}/home/raven/.rbenvrc"
+  RBENV_ROOT="" HOME="${BATS_TMPDIR}/home/raven" run rbenv echo ONCE_UPON_A_MIDNIGHT_DREARY
+  assert_success
+  assert_output "while I pondered weak and weary"
+}


### PR DESCRIPTION
Variables like `$RBENV_ROOT` have to be set somewhere if you can't live with defaults. As long as you use Bash as your login shell, you can set them in `.bash_profile`. But in other cases, you have to stick to defaults. Since it's non-interactive shell, `.bashrc` works neither.

Quite recently, I handed my laptop to someone else for a sec. If I only could set  $RBENV_ROOT to some shared location, I could create a new user who would use the same rubies as I do. Also, Homebrew suggests setting RBENV_ROOT to `/usr/local/var/rbenv`.

Sorry I'm drunk.
