### PR TITLE
Check for readlink / greadlink before trying to use them

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -12,14 +12,6 @@ if [ -n "$RBENV_DEBUG" ]; then
   set -x
 fi
 
-precheck() {
-  READLINK=$(type -p greadlink readlink | head -1)
-  if [ -z "$READLINK" ]; then
-    echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
-    exit 1
-  fi
-}
-
 resolve_link() {
   $READLINK "$1"
 }
@@ -57,7 +49,11 @@ else
 fi
 export RBENV_DIR
 
-precheck
+READLINK=$(type -p greadlink readlink | head -1)
+if [ -z "$READLINK" ]; then
+  echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
+  exit 1
+fi
 
 shopt -s nullglob
 

--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -20,7 +20,7 @@ if [ -z "$RBENV_COMMAND" ]; then
 fi
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) $1
+  $READLINK "$1"
 }
 
 realpath() {
@@ -38,6 +38,12 @@ realpath() {
 }
 
 IFS=: hook_paths=($RBENV_HOOK_PATH)
+
+READLINK=$(type -p greadlink readlink | head -1)
+if [ -z "$READLINK" ]; then
+  echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
+  exit 1
+fi
 
 shopt -s nullglob
 for path in "${hook_paths[@]}"; do

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -26,7 +26,7 @@ if [ -z "$shell" ]; then
 fi
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) $1
+  $READLINK "$1"
 }
 
 abs_dirname() {
@@ -42,6 +42,12 @@ abs_dirname() {
   pwd
   cd "$cwd"
 }
+
+READLINK=$(type -p greadlink readlink | head -1)
+if [ -z "$READLINK" ]; then
+  echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
+  exit 1
+fi
 
 root="$(abs_dirname "$0")/.."
 


### PR DESCRIPTION
Perform a preflight check to ensure that we have readlink or greadlink, exiting with failure if we don't.

readlink comes from GNU coreutils.  On systems without it, rbenv used to
spin out of control when it didn't have readlink or greadlink available
because it would re-exec the frontend script over and over instead of the
worker script in libexec.

Resolves issue #389
