### PR TITLE
Add possibility to select Ruby by version only, without a patch

### DIFF
--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -13,6 +13,13 @@ if [ -z "$RBENV_VERSION" ] || [ "$RBENV_VERSION" = "system" ]; then
   exit
 fi
 
+version_lookup() {
+  version="$1"
+  echo "$(rbenv-versions --bare | grep "$version" | sort -r | head -n1)"
+}
+
+RBENV_VERSION="$(version_lookup $RBENV_VERSION)"
+
 version_exists() {
   local version="$1"
   [ -d "${RBENV_ROOT}/versions/${version}" ]


### PR DESCRIPTION
It will be nice if there will be possible to select Ruby in more open-ended way. Like if I write `rbenv shell 2.0.0` it will select the newest installed Ruby version with selected prefix. There is [`rbenv-use`](https://github.com/rkh/rbenv-use) but it try to use last published Ruby with given prefix, not the newest installed.

In my [fish rbenv implementation](https://gist.github.com/hauleth/5337768) I have created function `rbenv_lookup` that find the newest installed Ruby with given prefix.

```
function rbenv_lookup
  set -l vers (command rbenv versions --bare | sort | grep -- "$argv[1]" | tail -n1)

  if [ ! -z "$vers" ]
    echo $vers
    return
  else
    echo $argv
    return
  end
end
```

I know that it's not ideal but work nicely, even if I write only `rbenv shell 2` it will change to the newest installed Ruby 2.
