### PR TITLE
Adding update version list to libexec

### DIFF
--- a/libexec/rbenv-update-versions
+++ b/libexec/rbenv-update-versions
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Summary: Show the current Ruby version and its origin
+# Summary: Updates the ruby versions by pulling them from remote
 #
-# Shows the currently selected Ruby version and how it was
-# selected. To obtain only the version string, use `rbenv
-# version-name'.
+# Updates all ruby versions, by cding to the rbenv/plugins directory
+# and doing a git pull origin master
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x


### PR DESCRIPTION
Added a way to update all versions by just typing `rbenv update-versions` from anywhere in the terminal without setting an rbenv path.

This hopefully solves this issue:
https://github.com/sstephenson/rbenv/issues/301
