### PR TITLE
Replace non-portable `typeset` with `local`.

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -91,7 +91,7 @@ commands=(`rbenv-commands --sh`)
 IFS="|"
 cat <<EOS
 rbenv() {
-  typeset command
+  local command
   command="\$1"
   if [ "\$#" -gt 0 ]; then
     shift


### PR DESCRIPTION
Dash doesn't recognize `typeset`.  To declare a local variable, use
`local` instead.
