### PR TITLE
Remove and readd shims path if already exists.

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -79,9 +79,11 @@ fi
 
 mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
-if [[ ":${PATH}:" != *:"${RBENV_ROOT}/shims":* ]]; then
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+if [[ ":${PATH}:" = *:"${RBENV_ROOT}/shims":* ]]; then
+  options=$([ "$shell" = "zsh" ] && echo "setopt shwordsplit;" || echo "")
+  echo 'export PATH=$('${options}'IFS=":";p=($PATH);IFS=" ";p=(${p[@]%%'${RBENV_ROOT}'/shims});IFS=":";echo "${p[*]}")'
 fi
+echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 
 case "$shell" in
 bash | zsh )

--- a/test/init.bats
+++ b/test/init.bats
@@ -38,9 +38,11 @@ load test_helper
   assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
-@test "doesn't add shims to PATH more than once" {
-  export PATH="${RBENV_ROOT}/shims:$PATH"
+@test "remove and readd shims path if already exists" {
+  local base_path="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin"
+  export PATH="${RBENV_ROOT}/shims:${base_path}"
   run rbenv-init -
   assert_success
-  refute_line 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  assert [ ${lines[0]##*IFS} = '=":";echo "${p[*]}")' ]
+  assert_line 1 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }


### PR DESCRIPTION
When using a terminal multiplexer(such as screen), the environment variable is set each time a new window opened, and the priority shims path int the $PATH goes down.
