### PR TITLE
rbenv can now initialize properly even without execution rights on $PWD

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -33,7 +33,7 @@ abs_dirname() {
   done
 
   pwd
-  cd "$cwd"
+  [ -z "$cwd" ] && cd "$cwd" || cd '/'
 }
 
 if [ -z "${RBENV_ROOT}" ]; then

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -46,7 +46,7 @@ abs_dirname() {
   done
 
   pwd
-  cd "$cwd"
+  [ -z "$cwd" ] && cd "$cwd" && cd '/'
 }
 
 root="$(abs_dirname "$0")/.."

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -46,7 +46,7 @@ abs_dirname() {
   done
 
   pwd
-  [ -z "$cwd" ] && cd "$cwd" && cd '/'
+  [ -z "$cwd" ] && cd "$cwd" || cd '/'
 }
 
 root="$(abs_dirname "$0")/.."

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -22,7 +22,7 @@ expand_path() {
 
   cd "$1"
   pwd
-  cd -
+  cd $OLDPWD
 }
 
 remove_from_path() {

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -20,10 +20,9 @@ expand_path() {
     return 1
   fi
 
-  local cwd="$(pwd)"
   cd "$1"
   pwd
-  cd "$cwd"
+  cd -
 }
 
 remove_from_path() {


### PR DESCRIPTION
With this revision, rbenv does not fail to initialize anymore when it is launched in a deleted directory or a directory that for some reason isn't accessible.

The changes just check if the old pwd is an executable file before trying to set is as the current directory.
If not, the current directory becomes the root.

Perhaps we shouldn't set any current directory if the old one is not accessible anymore.

Note that there is also warnings from rbenv-which which appear when trying to use rbenv from an unnaccessible directory. Though in such cases, rbenv still behaves normally: I didn't believe it was worth making a change.
