### PR TITLE
Reliably detect parent shell in `rbenv init`

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -22,7 +22,8 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(basename "$SHELL")"
+  shell="$(ps c -p $(ps -p $$ -o 'ppid=' 2>/dev/null) -o 'comm=' 2>/dev/null || true)"
+  shell="$(basename "${shell:-$SHELL}")"
 fi
 
 READLINK=$(type -p greadlink readlink | head -1)
@@ -99,6 +100,15 @@ if [[ ":${PATH}:" != *:"${RBENV_ROOT}/shims":* ]]; then
   ;;
   esac
 fi
+
+case "$shell" in
+fish )
+  echo "setenv RBENV_SHELL $shell"
+;;
+* )
+  echo "export RBENV_SHELL=$shell"
+;;
+esac
 
 completion="${root}/completions/rbenv.${shell}"
 [ -r "$completion" ] && echo ". '$completion'"

--- a/libexec/rbenv-sh-rehash
+++ b/libexec/rbenv-sh-rehash
@@ -7,7 +7,7 @@ if [ "$1" = "--complete" ]; then
   exec rbenv-rehash --complete
 fi
 
-shell="$(basename "$SHELL")"
+shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 # When rbenv shell integration is enabled, delegate to rbenv-rehash,
 # then tell the shell to empty its command lookup cache.

--- a/libexec/rbenv-sh-shell
+++ b/libexec/rbenv-sh-shell
@@ -24,7 +24,7 @@ if [ "$1" = "--complete" ]; then
 fi
 
 version="$1"
-shell="$(basename "$SHELL")"
+shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 if [ -z "$version" ]; then
   if [ -z "$RBENV_VERSION" ]; then

--- a/test/init.bats
+++ b/test/init.bats
@@ -19,14 +19,21 @@ load test_helper
 
 @test "setup shell completions" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
-  SHELL=/bin/bash run rbenv-init -
+  run rbenv-init - bash
   assert_success
   assert_line ". '${root}/libexec/../completions/rbenv.bash'"
 }
 
+@test "detect parent shell" {
+  root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
+  SHELL=/bin/false run rbenv-init -
+  assert_success
+  assert_line "export RBENV_SHELL=bash"
+}
+
 @test "setup shell completions (fish)" {
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
-  SHELL=/usr/bin/fish run rbenv-init -
+  run rbenv-init - fish
   assert_success
   assert_line ". '${root}/libexec/../completions/rbenv.fish'"
 }
@@ -39,28 +46,28 @@ load test_helper
 
 @test "adds shims to PATH" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin"
-  SHELL=/bin/bash run rbenv-init -
+  run rbenv-init - bash
   assert_success
   assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin"
-  SHELL=/usr/bin/fish run rbenv-init -
+  run rbenv-init - fish
   assert_success
   assert_line 0 "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
 @test "doesn't add shims to PATH more than once" {
   export PATH="${RBENV_ROOT}/shims:$PATH"
-  SHELL=/bin/bash run rbenv-init -
+  run rbenv-init - bash
   assert_success
   refute_line 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "doesn't add shims to PATH more than once (fish)" {
   export PATH="${RBENV_ROOT}/shims:$PATH"
-  SHELL=/usr/bin/fish run rbenv-init -
+  run rbenv-init - fish
   assert_success
   refute_line 'setenv PATH "'${RBENV_ROOT}'/shims" $PATH ;'
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -101,14 +101,14 @@ SH
 
 @test "sh-rehash in bash" {
   create_executable "2.0" "ruby"
-  SHELL=/bin/bash run rbenv-sh-rehash
+  RBENV_SHELL=bash run rbenv-sh-rehash
   assert_success "hash -r 2>/dev/null || true"
   assert [ -x "${RBENV_ROOT}/shims/ruby" ]
 }
 
 @test "sh-rehash in fish" {
   create_executable "2.0" "ruby"
-  SHELL=/usr/bin/fish run rbenv-sh-rehash
+  RBENV_SHELL=fish run rbenv-sh-rehash
   assert_success "hash -r 2>/dev/null ; or true"
   assert [ -x "${RBENV_ROOT}/shims/ruby" ]
 }

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -11,22 +11,22 @@ load test_helper
 }
 
 @test "shell version" {
-  SHELL=/bin/bash RBENV_VERSION="1.2.3" run rbenv-sh-shell
+  RBENV_SHELL=bash RBENV_VERSION="1.2.3" run rbenv-sh-shell
   assert_success 'echo "$RBENV_VERSION"'
 }
 
 @test "shell version (fish)" {
-  SHELL=/usr/bin/fish RBENV_VERSION="1.2.3" run rbenv-sh-shell
+  RBENV_SHELL=fish RBENV_VERSION="1.2.3" run rbenv-sh-shell
   assert_success 'echo "$RBENV_VERSION"'
 }
 
 @test "shell unset" {
-  SHELL=/bin/bash run rbenv-sh-shell --unset
+  RBENV_SHELL=bash run rbenv-sh-shell --unset
   assert_success "unset RBENV_VERSION"
 }
 
 @test "shell unset (fish)" {
-  SHELL=/usr/bin/fish run rbenv-sh-shell --unset
+  RBENV_SHELL=fish run rbenv-sh-shell --unset
   assert_success "set -e RBENV_VERSION"
 }
 
@@ -41,12 +41,12 @@ SH
 
 @test "shell change version" {
   mkdir -p "${RBENV_ROOT}/versions/1.2.3"
-  SHELL=/bin/bash run rbenv-sh-shell 1.2.3
+  RBENV_SHELL=bash run rbenv-sh-shell 1.2.3
   assert_success 'export RBENV_VERSION="1.2.3"'
 }
 
 @test "shell change version (fish)" {
   mkdir -p "${RBENV_ROOT}/versions/1.2.3"
-  SHELL=/usr/bin/fish run rbenv-sh-shell 1.2.3
+  RBENV_SHELL=fish run rbenv-sh-shell 1.2.3
   assert_success 'setenv RBENV_VERSION "1.2.3"'
 }


### PR DESCRIPTION
This addresses one of the most common issues that people have with rbenv: unreliable detection of their shell type when they eval the output of `rbenv init -`. #435 #260 #239 #383 #251 #185 #59

`$SHELL` variable is a terrible way of detecting the current shell because it's not even supposed to reflect the current shell; it's meant for keeping the value of the default shell for programs to start.

If an explicit `<shell>` argument wasn't passed to `rbenv init`, it tries to detect the shell by getting the name of its parent process. If this fails, it falls back on the value of `$SHELL` as before.

Furthermore, `rbenv init` will set the RBENV_SHELL variable in the current shell to the value of the detected shell so that `sh-shell` and `sh-rehash` commands don't have to repeat the detection.

This also enables spawning interactive subshells (e.g. zsh within bash) and having rbenv Just Work™ as long as each shell is configured to eval the output of `rbenv init -` in its profile settings.

/cc @sstephenson @josh  
/ht @envygeeks
