### PR TITLE
Updating version number in upgrade section

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ To use a specific release of rbenv, check out the corresponding tag:
 ~~~ sh
 $ cd ~/.rbenv
 $ git fetch
-$ git checkout v0.3.0
+$ git checkout v0.4.0
 ~~~
 
 If you've [installed via Homebrew](#homebrew-on-mac-os-x), then upgrade


### PR DESCRIPTION
Noticed that the version for the updating section is 2 years old.  Using newest tag version in the readme.
