### PR TITLE
ignore cache directory used by ruby-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /version
 /versions
 /sources
+/cache


### PR DESCRIPTION
ruby-build will cache downloaded packages into $RBENV_ROOT/cache - we ignore them
