### PR TITLE
Update ruby version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ should be able to:
 $ rbenv install -l
 
 # install a Ruby version:
-$ rbenv install 2.0.0-p247
+$ rbenv install 2.0.0-p353
 ~~~
 
 Alternatively to the `install` command, you can download and compile


### PR DESCRIPTION
Normally wouldn't worry about a trivial change like this, but the example version in the README uses a patch level that has a CVE. 

One of our team members got confused by this, so I figured others might as well.
