### PR TITLE
Remove Neckbeard reference in favor of Advanced

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ RVM?**](https://github.com/sstephenson/rbenv/wiki/Why-rbenv%3F)
   * [Basic GitHub Checkout](#basic-github-checkout)
     * [Upgrading](#upgrading)
   * [Homebrew on Mac OS X](#homebrew-on-mac-os-x)
-  * [Advanced Configuration](#advanced-configuration)
+  * [How rbenv hooks into your shell](#how-rbenv-hooks-into-your-shell)
   * [Installing Ruby Versions](#installing-ruby-versions)
   * [Uninstalling Ruby Versions](#uninstalling-ruby-versions)
 * [Command Reference](#command-reference)
@@ -233,7 +233,7 @@ Afterwards you'll still need to add `eval "$(rbenv init -)"` to your
 profile as stated in the caveats. You'll only ever have to do this
 once.
 
-### Advanced Configuration
+### How rbenv hooks into your shell
 
 Skip this section unless you must know what every line in your shell
 profile is doing.


### PR DESCRIPTION
At the risk of being over-sensitive because I do actually think the term neckbeard is amusing, the reference is:
- exclusionary of women, many of which who are more intelligent with their shell profiles than myself
- confusing/not as accessible to non-native English speakers

I think Advanced Configuration is more accessible and doesn't run the risk of offending anyone.

Sincerely,
Some guy with a really nice neck beard in real life and significantly less talent in shell profile "neckbearding"
