### PR TITLE
Prevent recursive calls of `rbenv` from unnecessarily repeat-adding to PATH and RBENV_HOOK_PATH.

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -58,17 +58,20 @@ export RBENV_DIR
 
 shopt -s nullglob
 
-bin_path="$(abs_dirname "$0")"
-for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
-  bin_path="${bin_path}:${plugin_bin}"
-done
-export PATH="${bin_path}:${PATH}"
+if [[ "$RBENV_ALREADY" = "" ]]; then
+  bin_path="$(abs_dirname "$0")"
+  for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
+    bin_path="${bin_path}:${plugin_bin}"
+  done
+  export PATH="${bin_path}:${PATH}"
 
-hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
-for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
-  hook_path="${hook_path}:${plugin_hook}"
-done
-export RBENV_HOOK_PATH="$hook_path"
+  hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
+  for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
+    hook_path="${hook_path}:${plugin_hook}"
+  done
+  export RBENV_HOOK_PATH="$hook_path"
+fi
+export RBENV_ALREADY=yes
 
 shopt -u nullglob
 

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -58,20 +58,17 @@ export RBENV_DIR
 
 shopt -s nullglob
 
-if [[ "$RBENV_ALREADY" = "" ]]; then
-  bin_path="$(abs_dirname "$0")"
-  for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
-    bin_path="${bin_path}:${plugin_bin}"
-  done
-  export PATH="${bin_path}:${PATH}"
+bin_path="$(abs_dirname "$0")"
+for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
+  bin_path="${bin_path}:${plugin_bin}"
+done
+export PATH="${bin_path}:${PATH}"
 
-  hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
-  for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
-    hook_path="${hook_path}:${plugin_hook}"
-  done
-  export RBENV_HOOK_PATH="$hook_path"
-fi
-export RBENV_ALREADY=yes
+hook_path="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
+for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
+  hook_path="${hook_path}:${plugin_hook}"
+done
+export RBENV_HOOK_PATH="$hook_path"
 
 shopt -u nullglob
 


### PR DESCRIPTION
This also (`RBENV_HOOK_PATH`) prevents rbenv from going through the hooks for a plugin more than once for each call of `rbenv` (try running, for example, `rake -V`).
