### PR TITLE
pick highest patch version for ambiguous ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ reading it from the following sources, in this order:
    file is not present, rbenv assumes you want to use the "system"
    Ruby—i.e. whatever version would be run if rbenv weren't in your
    path.
+   
+The lexicographically greatest patch number will be chosen if one is not
+provided.
 
 ### Locating the Ruby Installation
 

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -26,6 +26,16 @@ elif version_exists "${RBENV_VERSION#ruby-}"; then
   } >&2
   echo "${RBENV_VERSION#ruby-}"
 else
+  if [ -d "${RBENV_ROOT}/versions" ]; then
+    chosen_version="$(ls ${RBENV_ROOT}/versions | grep -e ${RBENV_VERSION} | tail -n 1)"
+    if [ -n "${chosen_version}" ] && [ -d ${RBENV_ROOT}/versions/${chosen_version} ]; then
+      { echo "warning: ambiguous ruby version \`${RBENV_VERSION}', using \`${chosen_version}'"
+      } >&2
+      echo "${chosen_version}"
+      exit
+    fi
+  fi
+
   echo "rbenv: version \`$RBENV_VERSION' is not installed" >&2
   exit 1
 fi

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -63,3 +63,26 @@ warning: ignoring extraneous \`ruby-' prefix in version \`ruby-1.8.7'
 1.8.7
 OUT
 }
+
+@test "ambiguous version chooses closest matching" {
+  create_version "1.9.3-p484"
+  create_version "1.9.3-p448"
+
+  cat > ".ruby-version" <<<"1.9.3"
+
+  run rbenv-version-name
+  assert_success
+  assert_output <<OUT
+warning: ambiguous ruby version \`1.9.3', using \`1.9.3-p484'
+1.9.3-p484
+OUT
+}
+
+@test "ambiguous version shouldn't choose wrong minor version" {
+  create_version "1.9.3-p484"
+
+  cat > ".ruby-version" <<<"1.9.4"
+
+  run rbenv-version-name
+  assert_failure "rbenv: version \`1.9.4' is not installed"
+}


### PR DESCRIPTION
A feature that I missed from RVM was specifying a Ruby version number down to the minor version and having RVM choose the best Ruby version to use. This is an initial stab at bringing that functionality to rbenv.

It could be further improved with flags to mute the errors or force strict ruby version compliance, but for the most part it should do the trick for now.

I'm open to suggestions on how to improve this pr.
