### PR TITLE
Fix test/versions.bats so that it won't fail on systems where no ruby is...

### DIFF
--- a/test/versions.bats
+++ b/test/versions.bats
@@ -11,11 +11,9 @@ setup() {
   cd "$RBENV_TEST_DIR"
 }
 
+# normalize for any missing system ruby (non-Mac OS X systems)!
 stub_system_ruby() {
-  run which ruby
-  [[ -n $output ]] && return
-
-  stub="${RBENV_TEST_DIR}/bin/ruby"
+  local stub="${RBENV_TEST_DIR}/bin/ruby"
   mkdir -p "$(dirname "$stub")"
   touch "$stub" && chmod +x "$stub"
 }


### PR DESCRIPTION
... installed by default. Closes #512.

Tested and working now on both systems with, and without a system ruby!
