### PR TITLE
Use 'read -n' instead of 'head -c' to improve compatibility

### DIFF
--- a/libexec/rbenv-version-file-read
+++ b/libexec/rbenv-version-file-read
@@ -8,7 +8,11 @@ VERSION_FILE="$1"
 if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
-  words=( $(head -c 1024 "$VERSION_FILE") )
+
+  # We don't want the read command to stop reading the file when it encounters 
+  # a newline so we tell it that newlines are delimited by a character we don't 
+  # expect to encounter in the file ever, namely: Ω
+  words=( $(read -dΩ -n1024 first_chars < "$VERSION_FILE"; echo $first_chars ) )
   version="${words[0]}"
 
   if [ -n "$version" ]; then


### PR DESCRIPTION
Fixes #519. The delimiter is a bit of a hack, the documentation for read would seem to indicate that -r would cause read to ignore newlines, but it doesn't seem to work on either OS X 10.9 or OpenBSD 5.4, so I chose this approach instead. 
- All tests pass on OS X 10.9. 
- The fix works on OpenBSD 5.4, but I don't have any tests working there yet, I'm getting a lot of "env: bash: No such file or directory" errors when I run 'bats test' there. 

Probably shouldn't merge until I can get the tests working on OpenBSD 5.4. Down the rabbit hole I go...
