### PR TITLE
Fixes rbenv on OpenBSD and any other systems that don't support head -c

### DIFF
--- a/libexec/rbenv-version-file-read
+++ b/libexec/rbenv-version-file-read
@@ -8,7 +8,7 @@ VERSION_FILE="$1"
 if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
-  words=( $(head -c 1024 "$VERSION_FILE") )
+  words=( $(cut -b 1-1024 "$VERSION_FILE") )
   version="${words[0]}"
 
   if [ -n "$version" ]; then


### PR DESCRIPTION
OpenBSD doesn't support 'head -c N'. See http://www.openbsd.org/cgi-bin/man.cgi?query=head&apropos=0&sektion=0&manpath=OpenBSD+Current&arch=i386&format=html

Using 'cut' with a byte range accomplishes the same thing.
