### PR TITLE
Avoid infinite loop in case where `pwd` returns relative path

### DIFF
--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -4,8 +4,8 @@ set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 find_local_version_file() {
-  local prev root="$1"
-  while [ -n "$root" ] && [ "$root" != "$prev" ]; do
+  local root="$1"
+  while [ -n "$root" ]; do
     if [ -e "${root}/.ruby-version" ]; then
       echo "${root}/.ruby-version"
       exit
@@ -13,7 +13,7 @@ find_local_version_file() {
       echo "${root}/.rbenv-version"
       exit
     fi
-    prev="${root}"
+    [ "${root}" = "${root%/*}" ] && break
     root="${root%/*}"
   done
 }

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -4,8 +4,8 @@ set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 find_local_version_file() {
-  local root="$1"
-  while [ -n "$root" ]; do
+  local prev root="$1"
+  while [ -n "$root" ] && [ "$root" != "$prev" ]; do
     if [ -e "${root}/.ruby-version" ]; then
       echo "${root}/.ruby-version"
       exit
@@ -13,6 +13,7 @@ find_local_version_file() {
       echo "${root}/.rbenv-version"
       exit
     fi
+    prev="${root}"
     root="${root%/*}"
   done
 }


### PR DESCRIPTION
The `pwd` may return relative path if the `$PWD` is badly declared in bash/zsh (e.g. `PWD="." bash`). To avoid the infinite loop in `find_local_version_file()`, stop finding the version file if the target paths are same consecutively.
