### PR TITLE
Fix broken test suite

### DIFF
--- a/test/which.bats
+++ b/test/which.bats
@@ -69,6 +69,7 @@ exit
 SH
 
   create_executable "6.6.6" "anything"
+
   RBENV_VERSION=6.6.6 RBENV_HOOK_PATH="$hook_path" IFS=$' \t\n' run rbenv-which anything
   assert_success
   assert_output "HELLO=:hello:ugly:world:again"


### PR DESCRIPTION
@sstephenson / @mislav - it appears that the `rbenv` test suite has been broken since 060f141;  the small change in this pull request ensures it's green once more... see [this comment](https://github.com/sstephenson/rbenv/commit/060f141b2174f9ab53b7c2c248ad8f426ec5c125#commitcomment-5108025) for more detail about the root cause for the test failure... thanks!

---

For reference:

``` sh
$ bats -t test
1..141
...
not ok 141 carries original IFS within hooks
# (in test file /.../rbenv/test/which.bats, line 28)
# command failed with exit status 1
$_
```
