### PR TITLE
New command: `rbenv install-dir`

### DIFF
--- a/libexec/rbenv-install-dir
+++ b/libexec/rbenv-install-dir
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Summary: Display the installation directory for a Ruby
+# Usage: rbenv install
+#
+# Displays the directory where a given version of Ruby should
+# be installed, if the current working directory is a Ruby
+# download.
+
+dir=$(basename $PWD)
+if [ ${dir:0:5} != 'ruby-' ]; then
+  echo 1>&2 "${dir} is not a Ruby"
+  exit 1
+fi
+
+ruby_dir=${dir:5}
+echo "$(rbenv root)/versions/${ruby_dir}"


### PR DESCRIPTION
`rbenv install-dir` will calculate the standard path for a new install of Ruby if executed in an unpacked Ruby source tarball. It can be used to easily set the prefix in the configure script, like so:

```
./configure --prefix=$(rbenv install-dir)
```
