### PR TITLE
Improve performance of rbenv-which

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -15,38 +15,6 @@ if [ "$1" = "--complete" ]; then
   exec rbenv shims --short
 fi
 
-expand_path() {
-  if [ ! -d "$1" ]; then
-    return 1
-  fi
-
-  local cwd="$(pwd)"
-  cd "$1"
-  pwd
-  cd "$cwd"
-}
-
-remove_from_path() {
-  local path_to_remove="$(expand_path "$1")"
-  local result=""
-
-  if [ -z "$path_to_remove" ]; then
-    echo "${PATH}"
-    return
-  fi
-
-  local paths
-  IFS=: paths=($PATH)
-
-  for path in "${paths[@]}"; do
-    path="$(expand_path "$path" || true)"
-    if [ -n "$path" ] && [ "$path" != "$path_to_remove" ]; then
-      result="${result}${path}:"
-    fi
-  done
-
-  echo "${result%:}"
-}
 
 RBENV_VERSION="$(rbenv-version-name)"
 RBENV_COMMAND="$1"
@@ -57,8 +25,18 @@ if [ -z "$RBENV_COMMAND" ]; then
 fi
 
 if [ "$RBENV_VERSION" = "system" ]; then
-  PATH="$(remove_from_path "${RBENV_ROOT}/shims")"
-  RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
+  # Remove shims from PATH. Use a loop, because Bash won't remove all ":foo:"
+  # in ":foo:foo:" in one go.
+  path=":$PATH:"
+  remove="${RBENV_ROOT}/shims"
+  while true; do
+    path_before="$path"
+    path="${path//:$remove:/:}"
+    if [[ "$path_before" = "$path" ]]; then
+      break
+    fi
+  done
+  RBENV_COMMAND_PATH="$(PATH=$path command -v "$RBENV_COMMAND" || true)"
 else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi

--- a/test/which.bats
+++ b/test/which.bats
@@ -31,6 +31,31 @@ create_executable() {
   assert_success "${RBENV_TEST_DIR}/bin/kill-all-humans"
 }
 
+@test "searches PATH for system version (shims prepended)" {
+  create_executable "${RBENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${RBENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="${RBENV_ROOT}/shims:$PATH" RBENV_VERSION=system run rbenv-which kill-all-humans
+  assert_success "${RBENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "searches PATH for system version (shims appended)" {
+  create_executable "${RBENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${RBENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="$PATH:${RBENV_ROOT}/shims" RBENV_VERSION=system run rbenv-which kill-all-humans
+  assert_success "${RBENV_TEST_DIR}/bin/kill-all-humans"
+}
+
+@test "searches PATH for system version (shims spread)" {
+  create_executable "${RBENV_TEST_DIR}/bin" "kill-all-humans"
+  create_executable "${RBENV_ROOT}/shims" "kill-all-humans"
+
+  PATH="${RBENV_ROOT}/shims:${RBENV_ROOT}/shims:/tmp/non-existent:$PATH:${RBENV_ROOT}/shims" \
+    RBENV_VERSION=system run rbenv-which kill-all-humans
+  assert_success "${RBENV_TEST_DIR}/bin/kill-all-humans"
+}
+
 @test "version not installed" {
   create_executable "2.0" "rspec"
   RBENV_VERSION=1.9 run rbenv-which rspec


### PR DESCRIPTION
This implements removing of the shims path element via bash
substitution, instead of jumping around in all the `$PATH` elements.

Initially submitted for `pyenv`, where `pyenv-which` slowed down a
particular plugin noticeably: https://github.com/yyuu/pyenv/pull/129
