### PR TITLE
support choosing an alternative malloc implementation

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -72,6 +72,9 @@ export RBENV_HOOK_PATH="$hook_path"
 
 shopt -u nullglob
 
+if [[ -e $RBENV_ALT_MALLOC ]] ; then
+  export LD_PRELOAD=$RBENV_ALT_MALLOC
+fi
 
 command="$1"
 case "$command" in


### PR DESCRIPTION
There is a lot of talk about the various malloc implementation (jemalloc/tcmalloc) on the ruby bugtracker.

This allows setting LD_PRELOAD for everything run via rbenv.
