### PR TITLE
Use '.' instead of 'source'.

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -37,7 +37,7 @@ OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks exec`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do
-  source "$script"
+  . "$script"
 done
 
 shift 1

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -149,7 +149,7 @@ IFS=$'\n' scripts=(`rbenv-hooks rehash`)
 IFS="$OLDIFS"
 
 for script in "${scripts[@]}"; do
-  source "$script"
+  . "$script"
 done
 
 # Change back to the shims directory to install the registered shims

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -67,7 +67,7 @@ OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks which`)
 IFS="$OLDIFS"
 for script in "${scripts[@]}"; do
-  source "$script"
+  . "$script"
 done
 
 if [ -x "$RBENV_COMMAND_PATH" ]; then

--- a/test/init.bats
+++ b/test/init.bats
@@ -21,7 +21,7 @@ load test_helper
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run rbenv-init - bash
   assert_success
-  assert_line "source '${root}/libexec/../completions/rbenv.bash'"
+  assert_line ". '${root}/libexec/../completions/rbenv.bash'"
 }
 
 @test "detect parent shell" {


### PR DESCRIPTION
This enhances compatibility with other shell like dash(1). The command
'eval "$(rbenv init -)"' may end up in a .zshenv file which in turns is called
by session initialization script. This way programs started by the window
manager (specially IDE such as Emacs) inherits from the right environment
and thus can use the ruby from rbenv. These initialization script may not use
bash(1).
