### PR TITLE
Prefer gawk over awk if both are available.

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -36,7 +36,7 @@ extract_initial_comment_block() {
 }
 
 collect_documentation() {
-  awk '
+  $(type -p gawk awk | head -1) '
     /^Summary:/ {
       summary = substr($0, 10)
       next


### PR DESCRIPTION
This fixes `rbenv help` on Solaris 11.1.
