### PR TITLE
Add hooks for `rbenv-init`

### DIFF
--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -8,6 +8,7 @@ set -e
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
   echo exec
+  echo init
   echo rehash
   echo which
   exit

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -156,6 +156,7 @@ EOS
 esac
 
 if [ "$shell" != "fish" ]; then
+OLDIFS="$IFS"
 IFS="|"
 cat <<EOS
   command="\$1"
@@ -171,4 +172,14 @@ cat <<EOS
   esac
 }
 EOS
+IFS="$OLDIFS"
 fi
+
+# Allow plugins to override initialization process.
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`rbenv-hooks init`)
+IFS="$OLDIFS"
+
+for script in "${scripts[@]}"; do
+  source "$script"
+done


### PR DESCRIPTION
This can allow plugins to implement their shell functions into user's shell.

For example, install following scripts as `${RBENV_ROOT}/rbenv.d/init/detect.bash` will detect the changes of the Ruby version in rbenv.

``` bash
cat <<EOF
_rbenv_hook() {
  if [ -n "\$OLD_RBENV_VERSION" ] && [[ "\$OLD_RBENV_VERSION" != "\$(rbenv version-name)" ]]; then
    echo "rbenv: Ruby version has been changed: \$OLD_RBENV_VERSION -> \$(rbenv version-name)"
  fi
  OLD_RBENV_VERSION="\$(rbenv version-name)"
};
if ! [[ "\$PROMPT_COMMAND" =~ _rbenv_hook ]]; then
  PROMPT_COMMAND="_rbenv_hook;\$PROMPT_COMMAND";
fi
EOF
```
