### PR TITLE
Export LD_LIBRARY_PATH

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -32,6 +32,7 @@ fi
 export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
+RBENV_LIB_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/lib"
 
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks exec`)
@@ -43,5 +44,6 @@ done
 shift 1
 if [ "$RBENV_VERSION" != "system" ]; then
   export PATH="${RBENV_BIN_PATH}:${PATH}"
+  export LD_LIBRARY_PATH=${RBENV_LIB_PATH}:${LD_LIBRARY_PATH}
 fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Export LD_LIBRARY_PATH for commands run with rbenv-exec so that libraries from rbenv managed rubies will take precedence over system libraries.

This looks likely to be a decent solution to issues sstephenson/ruby-build#119 and sstephenson/ruby-build#509 and should hopefully prevent any future ones from vendored libraries.
