### PR TITLE
Updating readme to include a note about removing .gem directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Version names to rbenv are simply the names of the directories in
 If you're on Mac OS X, consider
 [installing with Homebrew](#homebrew-on-mac-os-x).
 
+If you have a current system ruby or rvm installation, be sure to 
+remove your `~/.gem` directory if it exists.
+
 ### Basic GitHub Checkout
 
 This will get you going with the latest version of rbenv and make it


### PR DESCRIPTION
Adding a note under the installation section to clarify that you should remove the `.gem` directory from your home directory.

I found it difficult to debug and this would have saved me a lot of time. After following the current installation instructions (and having removed rvm) I could run `ruby -v` and get the rbenv ruby version I'd set with `rbenv global`, run `gem install rails` and see rails get installed, but running `rails new project` would tell me I needed to install the gem.

It wasn't until I found this [StackOverflow answer](http://stackoverflow.com/a/11146496/836205) with the random note about removing `~/.gem` that I could successfully use the rails command.

I think this is worth calling out in the README as it doesn't seem to be a particularly rare issue. I don't know enough about rbenv's shims and rubygems to know if there's an underlying issue that should be fixed.
