### PR TITLE
Fix version file descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ reading it from the following sources, in this order:
 
 2. The first `.ruby-version` file found by searching the directory of the
    script you are executing and each of its parent directories until reaching
-   the root of your filesystem.
+   the root of your filesystem.  You can modify the `.ruby-version` file
+   in the current working directory with the [`rbenv local`](#rbenv-local)
+   command.
 
-3. The first `.ruby-version` file found by searching the current working
-   directory and each of its parent directories until reaching the root of your
-   filesystem. You can modify the `.ruby-version` file in the current working
-   directory with the [`rbenv local`](#rbenv-local) command.
+3. The first `.rbenv-version` file found by searching the current working
+   directory and each of its parent directories until reaching the root
+   of your filesystem. Usage of this file is deprecated in favor of the
+   more universal `.ruby-version` file.
 
 4. The global `~/.rbenv/version` file. You can modify this file using
    the [`rbenv global`](#rbenv-global) command. If the global version


### PR DESCRIPTION
The `.ruby-version` file was described twice :)
