### PR TITLE
Speed up `rbenv rehash`

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -98,28 +98,17 @@ make_shims() {
   done
 }
 
-# Create an empty array for the list of registered shims and an empty
-# string to use as a search index.
-registered_shims=()
-registered_shims_index=""
+registered_shims=" "
 
-# We will keep track of shims registered for installation with the
-# global `registered_shims` array and with a global search index
-# string. The array will let us iterate over all registered shims. The
-# index string will let us quickly check whether a shim with the given
-# name has been registered or not.
+# Registers the name of a shim to be generated.
 register_shim() {
-  local shim="$@"
-  registered_shims["${#registered_shims[@]}"]="$shim"
-  registered_shims_index="$registered_shims_index/$shim/"
+  registered_shims="${registered_shims}${1} "
 }
 
-# To install all the registered shims, we iterate over the
-# `registered_shims` array and create a link if one does not already
-# exist.
+# Install all the shims registered via `make_shims` or `register_shim` directly.
 install_registered_shims() {
   local shim file
-  for shim in "${registered_shims[@]}"; do
+  for shim in $registered_shims; do
     file="${SHIM_PATH}/${shim}"
     [ -e "$file" ] || ln -f "$PROTOTYPE_SHIM_PATH" "$file"
   done
@@ -132,7 +121,7 @@ install_registered_shims() {
 remove_stale_shims() {
   local shim
   for shim in "$SHIM_PATH"/*; do
-    if [[ "$registered_shims_index" != *"/${shim##*/}/"* ]]; then
+    if [[ "$registered_shims" != *" ${shim##*/} "* ]]; then
       rm -f "$shim"
     fi
   done

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -53,7 +53,7 @@ ruby
 OUT
 }
 
-@test "removes stale shims" {
+@test "removes outdated shims" {
   mkdir -p "${RBENV_ROOT}/shims"
   touch "${RBENV_ROOT}/shims/oldshim1"
   chmod +x "${RBENV_ROOT}/shims/oldshim1"
@@ -65,6 +65,25 @@ OUT
   assert_success ""
 
   assert [ ! -e "${RBENV_ROOT}/shims/oldshim1" ]
+}
+
+@test "do exact matches when removing stale shims" {
+  create_executable "2.0" "unicorn_rails"
+  create_executable "2.0" "rspec-core"
+
+  rbenv-rehash
+
+  cp "$RBENV_ROOT"/shims/{rspec-core,rspec}
+  cp "$RBENV_ROOT"/shims/{rspec-core,rails}
+  cp "$RBENV_ROOT"/shims/{rspec-core,uni}
+  chmod +x "$RBENV_ROOT"/shims/{rspec,rails,uni}
+
+  run rbenv-rehash
+  assert_success ""
+
+  assert [ ! -e "${RBENV_ROOT}/shims/rails" ]
+  assert [ ! -e "${RBENV_ROOT}/shims/rake" ]
+  assert [ ! -e "${RBENV_ROOT}/shims/uni" ]
 }
 
 @test "binary install locations containing spaces" {


### PR DESCRIPTION
On my system that has 25 versions under rbenv, this speeds up rehash almost 3-fold:
- before: 391 ms
- after:  **134 ms**

This is achieved by removing duplicate names of executables before registering them as shims. Since most Rubies will share a lot of the same executable names ("ruby", "rake", "bundle", ...), this is a considerable reduction in number of shims registered.

@janko-m @bruno- Could you try this revision out and report if there was any speedup?
