### PR TITLE
Support executing binstubs from user gem install location

### DIFF
--- a/rbenv.d/exec/user-gems.bash
+++ b/rbenv.d/exec/user-gems.bash
@@ -1,0 +1,12 @@
+if [[ "$RBENV_COMMAND" = "gem" && "$RBENV_VERSION" != "system" ]]; then
+  # hax to reuse logic from `which` hook without repeating it
+  orig_command_path="$RBENV_COMMAND_PATH"
+  RBENV_COMMAND_PATH=""
+  source "${BASH_SOURCE%/*}/../which/user-gems.bash"
+  if [ -n "$RBENV_COMMAND_PATH" ]; then
+    # add user install location to PATH to silence RubyGems warning when installing
+    export PATH="${RBENV_COMMAND_PATH%/gem}:$PATH"
+  fi
+  RBENV_COMMAND_PATH="$orig_command_path"
+  unset orig_command_path
+fi

--- a/rbenv.d/rehash/user-gems.bash
+++ b/rbenv.d/rehash/user-gems.bash
@@ -1,0 +1,1 @@
+make_shims "${HOME}/.gem"/*/*/bin/*

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -5,7 +5,7 @@ if [ ! -x "$RBENV_COMMAND_PATH" ]; then
   1.9* ) gemdir="ruby/1.9.1" ;;
   2.* ) gemdir="ruby/${RBENV_VERSION:0:3}.0" ;;
   jruby-1.* ) gemdir="jruby/1.9" ;;
-  jruby-9000* ) gemdir="jruby/2.1" ;;
+  jruby-9* ) gemdir="jruby/2.1" ;;
   rbx-2.* ) gemdir="rbx/2.1" ;;
   esac
 

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -1,0 +1,17 @@
+if [ ! -x "$RBENV_COMMAND_PATH" ]; then
+  gemdir=""
+  case "$RBENV_VERSION" in
+  1.8* ) gemdir="ruby/1.8" ;;
+  1.9* ) gemdir="ruby/1.9.1" ;;
+  2.0* ) gemdir="ruby/2.0.0" ;;
+  2.1* ) gemdir="ruby/2.1.0" ;;
+  2.2* ) gemdir="ruby/2.2.0" ;;
+  jruby-1.* ) gemdir="jruby/1.9" ;;
+  jruby-9000* ) gemdir="jruby/2.1" ;;
+  rbx-2.* ) gemdir="rbx/2.1" ;;
+  esac
+
+  if [ -n "$gemdir" ]; then
+    RBENV_COMMAND_PATH="${HOME}/.gem/${gemdir}/bin/${RBENV_COMMAND}"
+  fi
+fi

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -3,9 +3,7 @@ if [ ! -x "$RBENV_COMMAND_PATH" ]; then
   case "$RBENV_VERSION" in
   1.8* ) gemdir="ruby/1.8" ;;
   1.9* ) gemdir="ruby/1.9.1" ;;
-  2.0* ) gemdir="ruby/2.0.0" ;;
-  2.1* ) gemdir="ruby/2.1.0" ;;
-  2.2* ) gemdir="ruby/2.2.0" ;;
+  2.* ) gemdir="ruby/${RBENV_VERSION:0:3}.0" ;;
   jruby-1.* ) gemdir="jruby/1.9" ;;
   jruby-9000* ) gemdir="jruby/2.1" ;;
   rbx-2.* ) gemdir="rbx/2.1" ;;

--- a/rbenv.d/which/user-gems.bash
+++ b/rbenv.d/which/user-gems.bash
@@ -12,4 +12,5 @@ if [ ! -x "$RBENV_COMMAND_PATH" ]; then
   if [ -n "$gemdir" ]; then
     RBENV_COMMAND_PATH="${HOME}/.gem/${gemdir}/bin/${RBENV_COMMAND}"
   fi
+  unset gemdir
 fi

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -111,3 +111,15 @@ SH
   run ruby -S rake
   assert_success "hello rake"
 }
+
+@test "adds user install location to PATH for gem command" {
+  export RBENV_VERSION="2.1.6"
+  create_executable "gem" <<SH
+#!$BASH
+echo "\$PATH"
+SH
+
+  RBENV_HOOK_PATH="${BATS_TEST_DIRNAME}/../rbenv.d" run rbenv-exec gem install lolcat
+
+  assert_output "${RBENV_ROOT}/versions/2.1.6/bin:${HOME}/.gem/ruby/2.1.0/bin:$PATH"
+}

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -3,7 +3,10 @@
 load test_helper
 
 create_executable() {
-  local bin="${RBENV_ROOT}/versions/${1}/bin"
+  local bin
+  if [[ $1 == */* ]]; then bin="$1"
+  else bin="${RBENV_ROOT}/versions/${1}/bin"
+  fi
   mkdir -p "$bin"
   touch "${bin}/$2"
   chmod +x "${bin}/$2"
@@ -116,6 +119,20 @@ SH
   RBENV_HOOK_PATH="$hook_path" IFS=$' \t\n' run rbenv-rehash
   assert_success
   assert_output "HELLO=:hello:ugly:world:again"
+}
+
+@test "include binstubs from user-gems" {
+  create_executable "${HOME}/.gem/ruby/2.0.0/bin/rake"
+  create_executable "${HOME}/.gem/jruby/1.9/bin/rspec"
+
+  RBENV_HOOK_PATH="${BATS_TEST_DIRNAME}/../rbenv.d" run rbenv-rehash
+  assert_success ""
+
+  run ls "${RBENV_ROOT}/shims"
+  assert_output <<OUT
+rake
+rspec
+OUT
 }
 
 @test "sh-rehash in bash" {

--- a/test/which.bats
+++ b/test/which.bats
@@ -84,6 +84,14 @@ The \`rspec' command exists in these Ruby versions:
 OUT
 }
 
+@test "executable found in user-gems" {
+  create_executable "2.0" "ruby"
+  create_executable "${HOME}/.gem/ruby/2.0.0/bin" "lolcat"
+
+  RBENV_HOOK_PATH="${BATS_TEST_DIRNAME}/../rbenv.d" RBENV_VERSION=2.0 run rbenv-which lolcat
+  assert_success "${HOME}/.gem/ruby/2.0.0/bin/lolcat"
+}
+
 @test "carries original IFS within hooks" {
   hook_path="${RBENV_TEST_DIR}/rbenv.d"
   mkdir -p "${hook_path}/which"


### PR DESCRIPTION
This brings in the functionality of [user-gems plugin](https://github.com/mislav/rbenv-user-gems).

Previously, when you did `gem install --user-install lolcat`, the "lolcat" executable will neither be found while rehashing nor available for execution. This confused users and made rbenv look like it was broken.

Caveats:
- `rbenv whence` isn't aware of user install locations
- User install locations for JRuby and Rubinius default to their default modes, i.e. this lookup isn't aware of `JRUBY_OPTS=--1.8` or `RBXOPT=-X19` or `--default-version` with which Rubinius was configured.
- Custom GEM_HOME location is not supported. If you're using a custom GEM_HOME for some reason, then you should also prepend that location's `bin/` directory to PATH. This way you skip rbenv altogether and are not dependent on its shims behavior.

Fixes #554, fixes #465

/cc @sstephenson
