### PR TITLE
Don't attempt to cd to path without permissions

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -43,7 +43,7 @@ abs_dirname() {
   done
 
   pwd
-  cd "$cwd"
+  test -x "$cwd" && cd "$cwd"
 }
 fi
 


### PR DESCRIPTION
Following scenario illustrates a situation when /bin/rbenv fails to init due to directory permissions:

```

[tvaraneckas@sandbox ~]$ sudo -u mongrel bash
/opt/rbenv/bin/rbenv: line 46: cd: /home/tvaraneckas: Permission denied
rbenv: no such command `init'
[mongrel@sandbox tvaraneckas]$ source /etc/profile
/opt/rbenv/bin/rbenv: line 46: cd: /home/tvaraneckas: Permission denied
rbenv: no such command `init'
```

The fix simply does not try to cd to forbidden path, and initialization succeeds.
