### PR TITLE
Fix shell version when invoked from a script

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -22,7 +22,7 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
   shell="$(basename "${shell:-$SHELL}")"

--- a/test/init.bats
+++ b/test/init.bats
@@ -94,3 +94,10 @@ load test_helper
   assert_line '  switch "$command"'
   refute_line '  case "$command" in'
 }
+
+@test "shell version in script" {
+  printf '#!/bin/sh\neval "$(rbenv-init -)"; echo $RBENV_SHELL' > ${BATS_TEST_DIRNAME}/script.sh
+  chmod +x ${BATS_TEST_DIRNAME}/script.sh
+  run ${BATS_TEST_DIRNAME}/script.sh
+  assert_success 'sh'
+}


### PR DESCRIPTION
When invoked from a shell script, `$(rbenv init -)` did not get the shell name correct.
It needs to look at the `args` value from `ps`.

Reported for pyenv at: https://github.com/yyuu/pyenv/issues/373