### PR TITLE
Expose version-name and version-origin hooks

### DIFF
--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -9,6 +9,8 @@ set -e
 if [ "$1" = "--complete" ]; then
   echo exec
   echo rehash
+  echo version-name
+  echo version-origin
   echo which
   exit
 fi

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -8,6 +8,13 @@ if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`rbenv-hooks version-name`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
 if [ -z "$RBENV_VERSION" ] || [ "$RBENV_VERSION" = "system" ]; then
   echo "system"
   exit

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -3,7 +3,16 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ -n "$RBENV_VERSION" ]; then
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`rbenv-hooks version-origin`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
+if [ -n "$RBENV_VERSION_ORIGIN" ]; then
+  echo "$RBENV_VERSION_ORIGIN"
+elif [ -n "$RBENV_VERSION" ]; then
   echo "RBENV_VERSION environment variable"
 else
   rbenv-version-file

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -2,11 +2,6 @@
 
 load test_helper
 
-create_hook() {
-  mkdir -p "$1/$2"
-  touch "$1/$2/$3"
-}
-
 @test "prints usage help given no argument" {
   run rbenv-hooks
   assert_failure "Usage: rbenv hooks <command>"
@@ -15,11 +10,13 @@ create_hook() {
 @test "prints list of hooks" {
   path1="${RBENV_TEST_DIR}/rbenv.d"
   path2="${RBENV_TEST_DIR}/etc/rbenv_hooks"
-  create_hook "$path1" exec "hello.bash"
-  create_hook "$path1" exec "ahoy.bash"
-  create_hook "$path1" exec "invalid.sh"
-  create_hook "$path1" which "boom.bash"
-  create_hook "$path2" exec "bueno.bash"
+  RBENV_HOOK_PATH="$path1"
+  create_hook exec "hello.bash"
+  create_hook exec "ahoy.bash"
+  create_hook exec "invalid.sh"
+  create_hook which "boom.bash"
+  RBENV_HOOK_PATH="$path2"
+  create_hook exec "bueno.bash"
 
   RBENV_HOOK_PATH="$path1:$path2" run rbenv-hooks exec
   assert_success
@@ -33,8 +30,10 @@ OUT
 @test "supports hook paths with spaces" {
   path1="${RBENV_TEST_DIR}/my hooks/rbenv.d"
   path2="${RBENV_TEST_DIR}/etc/rbenv hooks"
-  create_hook "$path1" exec "hello.bash"
-  create_hook "$path2" exec "ahoy.bash"
+  RBENV_HOOK_PATH="$path1"
+  create_hook exec "hello.bash"
+  RBENV_HOOK_PATH="$path2"
+  create_hook exec "ahoy.bash"
 
   RBENV_HOOK_PATH="$path1:$path2" run rbenv-hooks exec
   assert_success
@@ -45,8 +44,8 @@ OUT
 }
 
 @test "resolves relative paths" {
-  path="${RBENV_TEST_DIR}/rbenv.d"
-  create_hook "$path" exec "hello.bash"
+  RBENV_HOOK_PATH="${RBENV_TEST_DIR}/rbenv.d"
+  create_hook exec "hello.bash"
   mkdir -p "$HOME"
 
   RBENV_HOOK_PATH="${HOME}/../rbenv.d" run rbenv-hooks exec

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -123,3 +123,8 @@ path_without() {
   done
   echo "${path%:}"
 }
+
+create_hook() {
+  mkdir -p "${RBENV_ROOT}/rbenv.d/$1"
+  cat > "${RBENV_ROOT}/rbenv.d/$1/$2" <<<"$3"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -125,6 +125,6 @@ path_without() {
 }
 
 create_hook() {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/$1"
-  cat > "${RBENV_ROOT}/rbenv.d/$1/$2" <<<"$3"
+  mkdir -p "${RBENV_HOOK_PATH}/$1"
+  cat > "${RBENV_HOOK_PATH}/$1/$2" <<<"$3"
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -4,11 +4,6 @@ load test_helper
 
 export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
 
-create_hook() {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
-  cat > "${RBENV_ROOT}/rbenv.d/version-name/$1" <<<"$2"
-}
-
 create_version() {
   mkdir -p "${RBENV_ROOT}/versions/$1"
 }
@@ -36,7 +31,7 @@ setup() {
   RBENV_VERSION=1.8.7 run rbenv-version-name
   assert_success "1.8.7"
 
-  create_hook test.bash "RBENV_VERSION=1.9.3"
+  create_hook version-name test.bash "RBENV_VERSION=1.9.3"
   RBENV_VERSION=1.8.7 run rbenv-version-name
   assert_success "1.9.3"
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -2,6 +2,13 @@
 
 load test_helper
 
+export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
+
+create_hook() {
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
+  cat > "${RBENV_ROOT}/rbenv.d/version-name/$1" <<<"$2"
+}
+
 create_version() {
   mkdir -p "${RBENV_ROOT}/versions/$1"
 }
@@ -20,6 +27,18 @@ setup() {
 @test "system version is not checked for existance" {
   RBENV_VERSION=system run rbenv-version-name
   assert_success "system"
+}
+
+@test "RBENV_VERSION can be overridden by hook" {
+  create_version "1.8.7"
+  create_version "1.9.3"
+
+  RBENV_VERSION=1.8.7 run rbenv-version-name
+  assert_success "1.8.7"
+
+  create_hook test.bash "RBENV_VERSION=1.9.3"
+  RBENV_VERSION=1.8.7 run rbenv-version-name
+  assert_success "1.9.3"
 }
 
 @test "RBENV_VERSION has precedence over local" {

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -4,11 +4,6 @@ load test_helper
 
 export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
 
-create_hook() {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
-  cat > "${RBENV_ROOT}/rbenv.d/version-origin/$1" <<<"$2"
-}
-
 setup() {
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
@@ -46,7 +41,7 @@ setup() {
 
 @test "reports from hook" {
   touch .ruby-version
-  create_hook test.bash "RBENV_VERSION_ORIGIN=plugin"
+  create_hook version-origin test.bash "RBENV_VERSION_ORIGIN=plugin"
 
   RBENV_VERSION=1 run rbenv-version-origin
 

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -2,6 +2,13 @@
 
 load test_helper
 
+export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
+
+create_hook() {
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
+  cat > "${RBENV_ROOT}/rbenv.d/version-origin/$1" <<<"$2"
+}
+
 setup() {
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
@@ -35,4 +42,13 @@ setup() {
   touch .rbenv-version
   run rbenv-version-origin
   assert_success "${PWD}/.rbenv-version"
+}
+
+@test "reports from hook" {
+  touch .ruby-version
+  create_hook test.bash "RBENV_VERSION_ORIGIN=plugin"
+
+  RBENV_VERSION=1 run rbenv-version-origin
+
+  assert_success "plugin"
 }


### PR DESCRIPTION
- version-name hook
  It is invoked *after* the traditional `RBENV_VERSION` lookup. Which means hook scripts can interrogate `$RBENV_VERSION_FILE` and/or `$RBENV_VERSION` (or use the executables).

  The hooks are then run, giving plugins a chance to alter `RBENV_VERSION`. Once the hooks have run, we now have (in `$RBENV_VERSION`) the actual version we want to use (or it's empty which defaults to `system` per normal). Lastly, the same logic remains for checking if the version exists, or trimming the `ruby-` prefix.
- version-origin hook

  It is invoked *before* the traditional `rbenv-version-file` lookup. Because `version-origin` is usually run immediately after `version-name`, then any plugin hooks that alter `version-name` would have done so. Thus, running `version-origin` prior to printing the origin gives those plugins a chance to alter the `version-origin` to match. If any of the hooks set `$RBENV_VERSION_ORIGIN`, then it is used as the return value. Otherwise, the existing logic continues to return "environment variable" or "filename" as appropriate.

With both of these hooks in place, we have a clean seam by which plugins can inject their own ruby-version-setting logic. Until now, the only mechanism to available to alter the chosen ruby version was in the `which` hook. Using the `which` hook is error prone, however, since the hooks must build up the full
`RBENV_COMMAND_PATH` themselves. Further, with the `which` hook, commands like `rbenv version` will report a different ruby than they one that will actually be executed. And functions like `__rbenv_ps1` report the wrong ruby version.

Using these new hooks, plugins can safely manipulate the version of ruby chosen, while still leaving the executable-path-lookup to rbenv.