### PR TITLE
Don't export `$PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ easy to fork and contribute any changes back upstream.
    command-line utility.
 
     ~~~ sh
-    $ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
+    $ echo 'PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
     ~~~
 
     **Ubuntu Desktop note**: Modify your `~/.bashrc` instead of `~/.bash_profile`.

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -73,7 +73,7 @@ bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+PATH="${bin_path}:${PATH}"
 
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d"
 if [ "${bin_path%/*}" != "$RBENV_ROOT" ]; then

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -42,6 +42,6 @@ done
 
 shift 1
 if [ "$RBENV_VERSION" != "system" ]; then
-  export PATH="${RBENV_BIN_PATH}:${PATH}"
+  PATH="${RBENV_BIN_PATH}:${PATH}"
 fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -79,7 +79,7 @@ fish )
   echo "setenv RBENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  echo 'PATH="'${RBENV_ROOT}'/shims:${PATH}"'
   echo "export RBENV_SHELL=$shell"
 ;;
 esac

--- a/test/init.bats
+++ b/test/init.bats
@@ -51,28 +51,28 @@ load test_helper
 }
 
 @test "adds shims to PATH" {
-  export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
+  PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run rbenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  assert_line 0 'PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
-  export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
+  PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run rbenv-init - fish
   assert_success
   assert_line 0 "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
-  export PATH="${RBENV_ROOT}/shims:$PATH"
+  PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  assert_line 0 'PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "can add shims to PATH more than once (fish)" {
-  export PATH="${RBENV_ROOT}/shims:$PATH"
+  PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - fish
   assert_success
   assert_line 0 "setenv PATH '${RBENV_ROOT}/shims' \$PATH"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "blank invocation" {
   run rbenv
   assert_success
-  assert [ "${lines[0]}" = "$(rbenv---version)" ]
+  assert [ "${lines[0]}" = "rbenv 0.4.0" ]
 }
 
 @test "invalid command" {

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -5,7 +5,7 @@ load test_helper
 @test "blank invocation" {
   run rbenv
   assert_success
-  assert [ "${lines[0]}" = "rbenv 0.4.0" ]
+  assert [ "${lines[0]}" = "$(rbenv---version)" ]
 }
 
 @test "invalid command" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -23,7 +23,6 @@ if [ -z "$RBENV_TEST_DIR" ]; then
   PATH="${BATS_TEST_DIRNAME}/../libexec:$PATH"
   PATH="${BATS_TEST_DIRNAME}/libexec:$PATH"
   PATH="${RBENV_ROOT}/shims:$PATH"
-  export PATH
 
   for xdg_var in `env 2>/dev/null | grep ^XDG_ | cut -d= -f1`; do unset "$xdg_var"; done
   unset xdg_var


### PR DESCRIPTION
`PATH` does not need to be exported to be available to the shell. This
change removes instances where `PATH` is exported in `rbenv` and
`rbenv-init`. If a user has elected to export `PATH`, the changes rbenv
makes to the variable will continue to be reflected in the exported
variable.

Other change:
* Remove hard-coded version number in bare invocation test.