### PR TITLE
Detect `RBENV_DIR` properly from file argument to `ruby`

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -58,7 +58,13 @@ fi
 export RBENV_ROOT
 
 if [ -z "${RBENV_DIR}" ]; then
-  RBENV_DIR="$PWD"
+  # Transfer RBENV_FILE_ARG (from shims) into RBENV_DIR.
+  if [ -n "${RBENV_FILE_ARG}" ]; then
+    RBENV_DIR="$(abs_dirname "$(dirname "${RBENV_FILE_ARG}")/${RBENV_FILE_ARG##*/}")"
+    unset RBENV_FILE_ARG
+  else
+    RBENV_DIR="$PWD"
+  fi
 else
   cd "$RBENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$RBENV_DIR'"
   RBENV_DIR="$PWD"

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -50,9 +50,9 @@ if [ "\$program" = "ruby" ]; then
   for arg; do
     case "\$arg" in
     -e* | -- ) break ;;
-    */* )
+    * )
       if [ -f "\$arg" ]; then
-        export RBENV_DIR="\${arg%/*}"
+        export RBENV_FILE_ARG="\$arg"
         break
       fi
       ;;

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -46,6 +46,41 @@ load test_helper
   assert_output "rbenv: cannot change working directory to \`$dir'"
 }
 
+@test "RBENV_DIR should have higher precedence than RBENV_FILE_ARG" {
+  dir="${BATS_TMPDIR}/myproject"
+  mkdir -p "$dir"
+  touch "$dir/test.rb"
+  RBENV_DIR="$dir" RBENV_FILE_ARG="$dir/test.rb" run rbenv echo RBENV_DIR
+  assert_output "$dir"
+}
+
+@test "detect RBENV_DIR from RBENV_FILE_ARG" {
+  dir="${BATS_TMPDIR}/myproject"
+  mkdir -p "$dir"
+  touch "$dir/test.rb"
+  RBENV_FILE_ARG="$dir/test.rb" run rbenv echo RBENV_DIR
+  assert_output "$dir"
+}
+
+@test "detect RBENV_DIR from RBENV_FILE_ARG in current directory" {
+  dir="${BATS_TMPDIR}/myproject"
+  mkdir -p "$dir"
+  touch "$dir/test.rb"
+  cd "$dir"
+  BYENV_FILE_ARG="test.rb" run rbenv echo RBENV_DIR
+  assert_output "$dir"
+}
+
+@test "detect RBENV_DIR from RBENV_FILE_ARG via symlink" {
+  dir1="${BATS_TMPDIR}/myproject1"
+  dir2="${BATS_TMPDIR}/myproject2"
+  mkdir -p "$dir1" "$dir2"
+  touch "$dir1/test.rb"
+  ln -fs "$dir1/test.rb" "$dir2/test.rb"
+  RBENV_FILE_ARG="$dir2/test.rb" run rbenv echo RBENV_DIR
+  assert_output "$dir1"
+}
+
 @test "adds its own libexec to PATH" {
   run rbenv echo "PATH"
   assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"


### PR DESCRIPTION
I believe there are 2 weird behaviour relating to `RBENV_DIR`.  This should fix both 2.
1. file argument does not follow symlink (yyuu/pyenv#404)
2. file argument works weirdly if first argument doesn't contain `/` (yyuu/pyenv#479)

Both can be reproduced with the following setup.

``` sh
$ mkdir -p ./foo
$ echo 2.2.3 > ./foo/.ruby-version
$ echo 'puts(RUBY_DESCRIPTION)' > ./foo/test.rb
$ mkdir -p ./foo/bar
$ echo jruby-9.0.0.0 > ./foo/bar/.ruby-version
$ ln -sf ${PWD}/foo/test.rb ./foo/bar/
```

If the first file argument to `ruby` interpreter is a symlink, it'd be better to follow the link.

``` sh
$ ruby ./foo/test.rb
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
$ ruby ./foo/bar/test.rb
jruby 9.0.0.0 (2.2.2) 2015-07-21 e10ec96 OpenJDK 64-Bit Server VM 25.72-b05 on 1.8.0_72-internal-b05 +jit [linux-amd64]
```

`RBENV_DIR` just not working if the first file argument doesn't contain `/`.

``` sh
$ cd ./foo
$ ruby test.rb
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]
$ ruby test.rb ./bar/test.rb
jruby 9.0.0.0 (2.2.2) 2015-07-21 e10ec96 OpenJDK 64-Bit Server VM 25.72-b05 on 1.8.0_72-internal-b05 +jit [linux-amd64] # <-- this would be better to be 2.2.3
```
