### PR TITLE
Remove leading `:`

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -23,7 +23,8 @@ remove_from_path() {
     path_before="$result"
     result="${result//:$path_to_remove:/:}"
   done
-  echo "${result%:}"
+  result="${result%:}"
+  echo "${result#:}"
 }
 
 RBENV_COMMAND="$1"


### PR DESCRIPTION
Currently, `rbenv which` returns the current directory's command when RBENV_VERSION=system.

```
% ls -l ls
-rwxr-xr-x 1 eagletmt eagletmt 0 2015-12-12 15:36 ls
% which ls
/usr/bin/ls
% rbenv which ls
./ls
```

This patch fixes the issue.
