### PR TITLE
Only export the rbenv shims directory into the PATH if doesn't already exist

### DIFF
--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -9,6 +9,8 @@ set -e
 if [ "$1" = "--complete" ]; then
   echo exec
   echo rehash
+  echo version-name
+  echo version-origin
   echo which
   exit
 fi

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -83,14 +83,15 @@ if [ -z "$print" ]; then
 fi
 
 mkdir -p "${RBENV_ROOT}/"{shims,versions}
+SHIMS_PATH="${RBENV_ROOT}/shims"
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
+  echo "setenv PATH '${SHIMS_PATH}' \$PATH"
   echo "setenv RBENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  echo '[[ ":${PATH}:" != *":'${SHIMS_PATH}':"* ]] && export PATH="'${SHIMS_PATH}':${PATH}"'
   echo "export RBENV_SHELL=$shell"
 ;;
 esac

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -8,6 +8,13 @@ if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`rbenv-hooks version-name`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
 if [ -z "$RBENV_VERSION" ] || [ "$RBENV_VERSION" = "system" ]; then
   echo "system"
   exit

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -3,6 +3,8 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+unset RBENV_VERSION_ORIGIN
+
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks version-origin`)
 IFS="$OLDIFS"

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -3,7 +3,16 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-if [ -n "$RBENV_VERSION" ]; then
+OLDIFS="$IFS"
+IFS=$'\n' scripts=(`rbenv-hooks version-origin`)
+IFS="$OLDIFS"
+for script in "${scripts[@]}"; do
+  source "$script"
+done
+
+if [ -n "$RBENV_VERSION_ORIGIN" ]; then
+  echo "$RBENV_VERSION_ORIGIN"
+elif [ -n "$RBENV_VERSION" ]; then
   echo "RBENV_VERSION environment variable"
 else
   rbenv-version-file

--- a/test/init.bats
+++ b/test/init.bats
@@ -54,7 +54,7 @@ load test_helper
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run rbenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  assert_line 0 '[[ ":${PATH}:" != *":'${RBENV_ROOT}'/shims:"* ]] && export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "adds shims to PATH (fish)" {
@@ -68,7 +68,7 @@ load test_helper
   export PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  assert_line 0 '[[ ":${PATH}:" != *":'${RBENV_ROOT}'/shims:"* ]] && export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
 @test "can add shims to PATH more than once (fish)" {

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -2,6 +2,13 @@
 
 load test_helper
 
+export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
+
+create_hook() {
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
+  cat > "${RBENV_ROOT}/rbenv.d/version-name/$1" <<<"$2"
+}
+
 create_version() {
   mkdir -p "${RBENV_ROOT}/versions/$1"
 }
@@ -20,6 +27,18 @@ setup() {
 @test "system version is not checked for existance" {
   RBENV_VERSION=system run rbenv-version-name
   assert_success "system"
+}
+
+@test "RBENV_VERSION can be overridden by hook" {
+  create_version "1.8.7"
+  create_version "1.9.3"
+
+  RBENV_VERSION=1.8.7 run rbenv-version-name
+  assert_success "1.8.7"
+
+  create_hook test.bash "RBENV_VERSION=1.9.3"
+  RBENV_VERSION=1.8.7 run rbenv-version-name
+  assert_success "1.9.3"
 }
 
 @test "RBENV_VERSION has precedence over local" {

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -2,13 +2,6 @@
 
 load test_helper
 
-export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
-
-create_hook() {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
-  cat > "${RBENV_ROOT}/rbenv.d/version-name/$1" <<<"$2"
-}
-
 create_version() {
   mkdir -p "${RBENV_ROOT}/versions/$1"
 }
@@ -33,11 +26,12 @@ setup() {
   create_version "1.8.7"
   create_version "1.9.3"
 
-  RBENV_VERSION=1.8.7 run rbenv-version-name
-  assert_success "1.8.7"
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
+  cat > "${RBENV_ROOT}/rbenv.d/version-name/test.bash" <<HOOK
+RBENV_VERSION=1.9.3
+HOOK
 
-  create_hook test.bash "RBENV_VERSION=1.9.3"
-  RBENV_VERSION=1.8.7 run rbenv-version-name
+  RBENV_VERSION=1.8.7 RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d" run rbenv-version-name
   assert_success "1.9.3"
 }
 

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -2,13 +2,6 @@
 
 load test_helper
 
-export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
-
-create_hook() {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
-  cat > "${RBENV_ROOT}/rbenv.d/version-origin/$1" <<<"$2"
-}
-
 setup() {
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
@@ -45,11 +38,12 @@ setup() {
 }
 
 @test "reports from hook" {
-  touch .ruby-version
-  create_hook test.bash "RBENV_VERSION_ORIGIN=plugin"
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
+  cat > "${RBENV_ROOT}/rbenv.d/version-origin/test.bash" <<HOOK
+RBENV_VERSION_ORIGIN=plugin
+HOOK
 
-  RBENV_VERSION=1 run rbenv-version-origin
-
+  RBENV_VERSION=1 RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d" run rbenv-version-origin
   assert_success "plugin"
 }
 

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -52,3 +52,8 @@ setup() {
 
   assert_success "plugin"
 }
+
+@test "doesn't inherit RBENV_VERSION_ORIGIN from environment" {
+  RBENV_VERSION_ORIGIN=ignored run rbenv-version-origin
+  assert_success "${RBENV_ROOT}/version"
+}

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -2,6 +2,13 @@
 
 load test_helper
 
+export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
+
+create_hook() {
+  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
+  cat > "${RBENV_ROOT}/rbenv.d/version-origin/$1" <<<"$2"
+}
+
 setup() {
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
@@ -35,4 +42,13 @@ setup() {
   touch .rbenv-version
   run rbenv-version-origin
   assert_success "${PWD}/.rbenv-version"
+}
+
+@test "reports from hook" {
+  touch .ruby-version
+  create_hook test.bash "RBENV_VERSION_ORIGIN=plugin"
+
+  RBENV_VERSION=1 run rbenv-version-origin
+
+  assert_success "plugin"
 }


### PR DESCRIPTION
This only adds the shim path if it doesn't already match in the PATH. Does not prevent shims from being added multiple times (ie. `PATH="/path/to/shims:../../relative/path/to/shims:$PATH"`)