### PR TITLE
Add `--unset` to rbenv-global

### DIFF
--- a/libexec/rbenv-global
+++ b/libexec/rbenv-global
@@ -17,6 +17,7 @@ set -e
 
 # Provide rbenv completions
 if [ "$1" = "--complete" ]; then
+  echo --unset
   echo system
   exec rbenv-versions --bare
 fi

--- a/libexec/rbenv-global
+++ b/libexec/rbenv-global
@@ -22,7 +22,11 @@ if [ "$1" = "--complete" ]; then
 fi
 
 RBENV_VERSION="$1"
-RBENV_VERSION_FILE="${RBENV_ROOT}/version"
+RBENV_VERSION_FILE="${RBENV_ROOT:?}/version"
+
+if [ "$1" = "--unset" ]; then
+  exec rm -f "$RBENV_VERSION_FILE" "${RBENV_ROOT:?}/global" "${RBENV_ROOT:?}/default"
+fi
 
 if [ -n "$RBENV_VERSION" ]; then
   rbenv-version-file-write "$RBENV_VERSION_FILE" "$RBENV_VERSION"

--- a/test/global.bats
+++ b/test/global.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 @test "default" {
-  run rbenv global
+  run rbenv-global
   assert_success
   assert_output "system"
 }
@@ -28,4 +28,16 @@ load test_helper
   mkdir -p "$RBENV_ROOT"
   run rbenv-global "1.2.3"
   assert_failure "rbenv: version \`1.2.3' not installed"
+}
+
+@test "unset (remove) RBENV_ROOT/version" {
+  mkdir -p "$RBENV_ROOT"
+  echo "1.2.3" > "$RBENV_ROOT/version"
+
+  run rbenv-global --unset
+  assert_success
+
+  assert [ ! -e $RBENV_ROOT/version ]
+  run rbenv-global
+  assert_output "system"
 }


### PR DESCRIPTION
Support unsetting global ruby version. Makes `rbenv global` consistent with
`rbenv local` and `rbenv shell`
