### PR TITLE
Remove all handling/support of .rbenv-version files

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,11 +374,6 @@ configured local version. You can also unset the local version:
 
     $ rbenv local --unset
 
-Previous versions of rbenv stored local version specifications in a
-file named `.rbenv-version`. For backwards compatibility, rbenv will
-read a local version specified in an `.rbenv-version` file, but a
-`.ruby-version` file in the same directory will take precedence.
-
 ### rbenv global
 
 Sets the global version of Ruby to be used in all shells by writing

--- a/libexec/rbenv-local
+++ b/libexec/rbenv-local
@@ -15,10 +15,6 @@
 # `RBENV_VERSION' environment variable takes precedence over local
 # and global versions.
 #
-# For backwards compatibility, rbenv will also read version
-# specifications from `.rbenv-version' files, but a `.ruby-version'
-# file in the same directory takes precedence.
-#
 # <version> should be a string matching a Ruby version known to rbenv.
 # The special version string `system' will use your default system Ruby.
 # Run `rbenv versions' for a list of available Ruby versions.
@@ -36,16 +32,9 @@ fi
 RBENV_VERSION="$1"
 
 if [ "$RBENV_VERSION" = "--unset" ]; then
-  rm -f .ruby-version .rbenv-version
+  rm -f .ruby-version
 elif [ -n "$RBENV_VERSION" ]; then
-  previous_file="$(RBENV_VERSION= rbenv-version-origin || true)"
   rbenv-version-file-write .ruby-version "$RBENV_VERSION"
-  if [ "$previous_file" -ef .rbenv-version ]; then
-    rm -f .rbenv-version
-    { echo "rbenv: removed existing \`.rbenv-version' file and migrated"
-      echo "       local version specification to \`.ruby-version' file"
-    } >&2
-  fi
 else
   if version_file="$(rbenv-version-file "$PWD")"; then
     rbenv-version-file-read "$version_file"

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -12,9 +12,6 @@ find_local_version_file() {
     if [ -e "${root}/.ruby-version" ]; then
       echo "${root}/.ruby-version"
       return 0
-    elif [ -e "${root}/.rbenv-version" ]; then
-      echo "${root}/.rbenv-version"
-      return 0
     fi
     [ -n "$root" ] || break
     root="${root%/*}"

--- a/test/local.bats
+++ b/test/local.bats
@@ -92,7 +92,7 @@ OUT
   touch .ruby-version
   run rbenv-local --unset
   assert_success ""
-  assert [ ! -e .rbenv-version ]
+  assert [ ! -e .ruby-version ]
 }
 
 @test "unsets alternate version file" {

--- a/test/local.bats
+++ b/test/local.bats
@@ -19,19 +19,6 @@ setup() {
   assert_success "1.2.3"
 }
 
-@test "supports legacy .rbenv-version file" {
-  echo "1.2.3" > .rbenv-version
-  run rbenv-local
-  assert_success "1.2.3"
-}
-
-@test "local .ruby-version has precedence over .rbenv-version" {
-  echo "1.8" > .rbenv-version
-  echo "2.0" > .ruby-version
-  run rbenv-local
-  assert_success "2.0"
-}
-
 @test "discovers version file in parent directory" {
   echo "1.2.3" > .ruby-version
   mkdir -p "subdir" && cd "subdir"
@@ -64,40 +51,9 @@ setup() {
   assert [ "$(cat .ruby-version)" = "1.2.3" ]
 }
 
-@test "renames .rbenv-version to .ruby-version" {
-  echo "1.8.7" > .rbenv-version
-  mkdir -p "${RBENV_ROOT}/versions/1.9.3"
-  run rbenv-local
-  assert_success "1.8.7"
-  run rbenv-local "1.9.3"
-  assert_success
-  assert_output <<OUT
-rbenv: removed existing \`.rbenv-version' file and migrated
-       local version specification to \`.ruby-version' file
-OUT
-  assert [ ! -e .rbenv-version ]
-  assert [ "$(cat .ruby-version)" = "1.9.3" ]
-}
-
-@test "doesn't rename .rbenv-version if changing the version failed" {
-  echo "1.8.7" > .rbenv-version
-  assert [ ! -e "${RBENV_ROOT}/versions/1.9.3" ]
-  run rbenv-local "1.9.3"
-  assert_failure "rbenv: version \`1.9.3' not installed"
-  assert [ ! -e .ruby-version ]
-  assert [ "$(cat .rbenv-version)" = "1.8.7" ]
-}
-
 @test "unsets local version" {
   touch .ruby-version
   run rbenv-local --unset
   assert_success ""
   assert [ ! -e .ruby-version ]
-}
-
-@test "unsets alternate version file" {
-  touch .rbenv-version
-  run rbenv-local --unset
-  assert_success ""
-  assert [ ! -e .rbenv-version ]
 }

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -45,19 +45,6 @@ create_file() {
   assert_success "${RBENV_TEST_DIR}/.ruby-version"
 }
 
-@test "legacy file in current directory" {
-  create_file ".rbenv-version"
-  run rbenv-version-file
-  assert_success "${RBENV_TEST_DIR}/.rbenv-version"
-}
-
-@test ".ruby-version has precedence over legacy file" {
-  create_file ".ruby-version"
-  create_file ".rbenv-version"
-  run rbenv-version-file
-  assert_success "${RBENV_TEST_DIR}/.ruby-version"
-}
-
 @test "in parent directory" {
   create_file ".ruby-version"
   mkdir -p project
@@ -72,14 +59,6 @@ create_file() {
   cd project
   run rbenv-version-file
   assert_success "${RBENV_TEST_DIR}/project/.ruby-version"
-}
-
-@test "legacy file has precedence if higher" {
-  create_file ".ruby-version"
-  create_file "project/.rbenv-version"
-  cd project
-  run rbenv-version-file
-  assert_success "${RBENV_TEST_DIR}/project/.rbenv-version"
 }
 
 @test "RBENV_DIR has precedence over PWD" {

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -31,12 +31,6 @@ setup() {
   assert_success "${PWD}/.ruby-version"
 }
 
-@test "detects alternate version file" {
-  touch .rbenv-version
-  run rbenv-version-origin
-  assert_success "${PWD}/.rbenv-version"
-}
-
 @test "reports from hook" {
   mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
   cat > "${RBENV_ROOT}/rbenv.d/version-origin/test.bash" <<HOOK


### PR DESCRIPTION
closes #846

Rbenv migrated from rbenv-version to ruby-version files in late 2012.

It's been nearly 3 years now and 1.0 has been released. This PR removes support for the legacy file: .rbenv-version