### PR TITLE
Remove support for legacy global version files

### DIFF
--- a/libexec/rbenv-global
+++ b/libexec/rbenv-global
@@ -27,8 +27,5 @@ RBENV_VERSION_FILE="${RBENV_ROOT}/version"
 if [ -n "$RBENV_VERSION" ]; then
   rbenv-version-file-write "$RBENV_VERSION_FILE" "$RBENV_VERSION"
 else
-  rbenv-version-file-read "$RBENV_VERSION_FILE" ||
-  rbenv-version-file-read "${RBENV_ROOT}/global" ||
-  rbenv-version-file-read "${RBENV_ROOT}/default" ||
-  echo system
+  rbenv-version-file-read "$RBENV_VERSION_FILE" || echo system
 fi

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -25,15 +25,7 @@ find_local_version_file() {
 find_global_version_file() {
   local global_version_file="${RBENV_ROOT}/version"
 
-  if [ -e "$global_version_file" ]; then
-    echo "$global_version_file"
-  elif [ -e "${RBENV_ROOT}/global" ]; then
-    echo "${RBENV_ROOT}/global"
-  elif [ -e "${RBENV_ROOT}/default" ]; then
-    echo "${RBENV_ROOT}/default"
-  else
-    echo "$global_version_file"
-  fi
+  echo "$global_version_file"
 }
 
 if [ -n "$target_dir" ]; then

--- a/test/global.bats
+++ b/test/global.bats
@@ -3,7 +3,7 @@
 load test_helper
 
 @test "default" {
-  run rbenv global
+  run rbenv-global
   assert_success
   assert_output "system"
 }
@@ -20,7 +20,7 @@ load test_helper
   mkdir -p "$RBENV_ROOT/versions/1.2.3"
   run rbenv-global "1.2.3"
   assert_success
-  run rbenv global
+  run rbenv-global
   assert_success "1.2.3"
 }
 

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -12,29 +12,15 @@ create_file() {
   touch "$1"
 }
 
-@test "prints global file if no version files exist" {
-  assert [ ! -e "${RBENV_ROOT}/version" ]
-  assert [ ! -e ".ruby-version" ]
+@test "detects global 'version' file" {
+  create_file "${RBENV_ROOT}/version"
   run rbenv-version-file
   assert_success "${RBENV_ROOT}/version"
 }
 
-@test "detects 'global' file" {
-  create_file "${RBENV_ROOT}/global"
-  run rbenv-version-file
-  assert_success "${RBENV_ROOT}/global"
-}
-
-@test "detects 'default' file" {
-  create_file "${RBENV_ROOT}/default"
-  run rbenv-version-file
-  assert_success "${RBENV_ROOT}/default"
-}
-
-@test "'version' has precedence over 'global' and 'default'" {
-  create_file "${RBENV_ROOT}/version"
-  create_file "${RBENV_ROOT}/global"
-  create_file "${RBENV_ROOT}/default"
+@test "prints global file if no version files exist" {
+  assert [ ! -e "${RBENV_ROOT}/version" ]
+  assert [ ! -e ".ruby-version" ]
   run rbenv-version-file
   assert_success "${RBENV_ROOT}/version"
 }


### PR DESCRIPTION
In the spirit of #849, I propose we remove the `default` and `global` legacy fallbacks for the global filename (`$RBENV_ROOT/version` has been the preferred filename since late 2011)

`default` was made legacy back in 2011 with 5be66da9f4053137a320058495031d0af6db29b4 (the command was renamed from `rbenv-default` to `rbenv-global`, and so the global file was renamed from `$RBENV_ROOT/default` to `$RBENV_ROOT/global` (the latter taking precedence)

`global` was then made legacy about a month later in Sep 2011 with 0a4ffcd15f6d02f9c707af008d9c2542dc1f864d when the preferred filename was changed to `$RBENV_ROOT/version`.