### PR TITLE
Extract hook helper

### DIFF
--- a/test/exec.bats
+++ b/test/exec.bats
@@ -44,15 +44,13 @@ OUT
 }
 
 @test "carries original IFS within hooks" {
-  hook_path="${RBENV_TEST_DIR}/rbenv.d"
-  mkdir -p "${hook_path}/exec"
-  cat > "${hook_path}/exec/hello.bash" <<SH
+  create_hook exec hello.bash <<SH
 hellos=(\$(printf "hello\\tugly world\\nagain"))
 echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
 SH
 
   export RBENV_VERSION=system
-  RBENV_HOOK_PATH="$hook_path" IFS=$' \t\n' run rbenv-exec env
+  IFS=$' \t\n' run rbenv-exec env
   assert_success
   assert_line "HELLO=:hello:ugly:world:again"
 }

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -43,17 +43,6 @@ ruby
 OUT
 }
 
-@test "supports hook path with spaces" {
-  hook_path="${RBENV_TEST_DIR}/custom stuff/rbenv hooks"
-  mkdir -p "${hook_path}/exec"
-  echo "export HELLO='from hook'" > "${hook_path}/exec/hello.bash"
-
-  export RBENV_VERSION=system
-  RBENV_HOOK_PATH="$hook_path" run rbenv-exec env
-  assert_success
-  assert_line "HELLO=from hook"
-}
-
 @test "carries original IFS within hooks" {
   hook_path="${RBENV_TEST_DIR}/rbenv.d"
   mkdir -p "${hook_path}/exec"

--- a/test/hooks.bats
+++ b/test/hooks.bats
@@ -2,11 +2,6 @@
 
 load test_helper
 
-create_hook() {
-  mkdir -p "$1/$2"
-  touch "$1/$2/$3"
-}
-
 @test "prints usage help given no argument" {
   run rbenv-hooks
   assert_failure "Usage: rbenv hooks <command>"
@@ -15,11 +10,13 @@ create_hook() {
 @test "prints list of hooks" {
   path1="${RBENV_TEST_DIR}/rbenv.d"
   path2="${RBENV_TEST_DIR}/etc/rbenv_hooks"
-  create_hook "$path1" exec "hello.bash"
-  create_hook "$path1" exec "ahoy.bash"
-  create_hook "$path1" exec "invalid.sh"
-  create_hook "$path1" which "boom.bash"
-  create_hook "$path2" exec "bueno.bash"
+  RBENV_HOOK_PATH="$path1"
+  create_hook exec "hello.bash"
+  create_hook exec "ahoy.bash"
+  create_hook exec "invalid.sh"
+  create_hook which "boom.bash"
+  RBENV_HOOK_PATH="$path2"
+  create_hook exec "bueno.bash"
 
   RBENV_HOOK_PATH="$path1:$path2" run rbenv-hooks exec
   assert_success
@@ -33,8 +30,10 @@ OUT
 @test "supports hook paths with spaces" {
   path1="${RBENV_TEST_DIR}/my hooks/rbenv.d"
   path2="${RBENV_TEST_DIR}/etc/rbenv hooks"
-  create_hook "$path1" exec "hello.bash"
-  create_hook "$path2" exec "ahoy.bash"
+  RBENV_HOOK_PATH="$path1"
+  create_hook exec "hello.bash"
+  RBENV_HOOK_PATH="$path2"
+  create_hook exec "ahoy.bash"
 
   RBENV_HOOK_PATH="$path1:$path2" run rbenv-hooks exec
   assert_success
@@ -45,8 +44,8 @@ OUT
 }
 
 @test "resolves relative paths" {
-  path="${RBENV_TEST_DIR}/rbenv.d"
-  create_hook "$path" exec "hello.bash"
+  RBENV_HOOK_PATH="${RBENV_TEST_DIR}/rbenv.d"
+  create_hook exec "hello.bash"
   mkdir -p "$HOME"
 
   RBENV_HOOK_PATH="${HOME}/../rbenv.d" run rbenv-hooks exec

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -70,6 +70,7 @@ load test_helper
 }
 
 @test "RBENV_HOOK_PATH includes rbenv built-in plugins" {
+  unset RBENV_HOOK_PATH
   run rbenv echo "RBENV_HOOK_PATH"
   assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME%/*}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -105,15 +105,13 @@ OUT
 }
 
 @test "carries original IFS within hooks" {
-  hook_path="${RBENV_TEST_DIR}/rbenv.d"
-  mkdir -p "${hook_path}/rehash"
-  cat > "${hook_path}/rehash/hello.bash" <<SH
+  create_hook rehash hello.bash <<SH
 hellos=(\$(printf "hello\\tugly world\\nagain"))
 echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
 exit
 SH
 
-  RBENV_HOOK_PATH="$hook_path" IFS=$' \t\n' run rbenv-rehash
+  IFS=$' \t\n' run rbenv-rehash
   assert_success
   assert_output "HELLO=:hello:ugly:world:again"
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -17,6 +17,7 @@ if [ -z "$RBENV_TEST_DIR" ]; then
 
   export RBENV_ROOT="${RBENV_TEST_DIR}/root"
   export HOME="${RBENV_TEST_DIR}/home"
+  export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
   PATH="${RBENV_TEST_DIR}/bin:$PATH"
@@ -128,4 +129,12 @@ path_without() {
   done
   path="${path#:}"
   echo "${path%:}"
+}
+
+create_hook() {
+  mkdir -p "${RBENV_HOOK_PATH}/$1"
+  touch "${RBENV_HOOK_PATH}/$1/$2"
+  if [ ! -t 0 ]; then
+    cat > "${RBENV_HOOK_PATH}/$1/$2"
+  fi
 }

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -31,6 +31,18 @@ setup() {
   assert_success "1.9.3"
 }
 
+@test "carries original IFS within hooks" {
+  create_hook version-name hello.bash <<SH
+hellos=(\$(printf "hello\\tugly world\\nagain"))
+echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
+SH
+
+  export RBENV_VERSION=system
+  IFS=$' \t\n' run rbenv-version-name env
+  assert_success
+  assert_line "HELLO=:hello:ugly:world:again"
+}
+
 @test "RBENV_VERSION has precedence over local" {
   create_version "1.8.7"
   create_version "1.9.3"

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -25,13 +25,9 @@ setup() {
 @test "RBENV_VERSION can be overridden by hook" {
   create_version "1.8.7"
   create_version "1.9.3"
+  create_hook version-name test.bash <<<"RBENV_VERSION=1.9.3"
 
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-name"
-  cat > "${RBENV_ROOT}/rbenv.d/version-name/test.bash" <<HOOK
-RBENV_VERSION=1.9.3
-HOOK
-
-  RBENV_VERSION=1.8.7 RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d" run rbenv-version-name
+  RBENV_VERSION=1.8.7 run rbenv-version-name
   assert_success "1.9.3"
 }
 

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -32,12 +32,9 @@ setup() {
 }
 
 @test "reports from hook" {
-  mkdir -p "${RBENV_ROOT}/rbenv.d/version-origin"
-  cat > "${RBENV_ROOT}/rbenv.d/version-origin/test.bash" <<HOOK
-RBENV_VERSION_ORIGIN=plugin
-HOOK
+  create_hook version-origin test.bash <<<"RBENV_VERSION_ORIGIN=plugin"
 
-  RBENV_VERSION=1 RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d" run rbenv-version-origin
+  RBENV_VERSION=1 run rbenv-version-origin
   assert_success "plugin"
 }
 

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -38,6 +38,18 @@ setup() {
   assert_success "plugin"
 }
 
+@test "carries original IFS within hooks" {
+  create_hook version-origin hello.bash <<SH
+hellos=(\$(printf "hello\\tugly world\\nagain"))
+echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
+SH
+
+  export RBENV_VERSION=system
+  IFS=$' \t\n' run rbenv-version-origin env
+  assert_success
+  assert_line "HELLO=:hello:ugly:world:again"
+}
+
 @test "doesn't inherit RBENV_VERSION_ORIGIN from environment" {
   RBENV_VERSION_ORIGIN=ignored run rbenv-version-origin
   assert_success "${RBENV_ROOT}/version"

--- a/test/which.bats
+++ b/test/which.bats
@@ -101,15 +101,13 @@ OUT
 }
 
 @test "carries original IFS within hooks" {
-  hook_path="${RBENV_TEST_DIR}/rbenv.d"
-  mkdir -p "${hook_path}/which"
-  cat > "${hook_path}/which/hello.bash" <<SH
+  create_hook which hello.bash <<SH
 hellos=(\$(printf "hello\\tugly world\\nagain"))
 echo HELLO="\$(printf ":%s" "\${hellos[@]}")"
 exit
 SH
 
-  RBENV_HOOK_PATH="$hook_path" IFS=$' \t\n' RBENV_VERSION=system run rbenv-which anything
+  IFS=$' \t\n' RBENV_VERSION=system run rbenv-which anything
   assert_success
   assert_output "HELLO=:hello:ugly:world:again"
 }


### PR DESCRIPTION
`create_hook` already existed in `hooks.bats`. The essential body of create_hook was already in use in `exec.bats`, `rehash.bats`, `version-name.bats`, `version-origin.bats` and `which.bats`.

Extracted existing create_hook helper from hooks.bats. Modified it to write the hook to `RBENV_HOOK_PATH` and to accept hook body from stdin.