### PR TITLE
silence broken pipe errors from type/head

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -42,7 +42,7 @@ extract_initial_comment_block() {
 }
 
 collect_documentation() {
-  $(type -p gawk awk | head -1) '
+  $(type -p gawk awk 2>/dev/null | head -1) '
     /^Summary:/ {
       summary = substr($0, 10)
       next


### PR DESCRIPTION
Occasionally (very rarely), I've encountered broken-pipe errors from rbenv-help. The underlying issue is that `head` can terminate and close its STDIN before the previous process in the pipeline is finished. If the upstream process doesn't properly handle SIGPIPE (or inherits SIG_IGN), then the upstream process can error out.

The scenario that I've encountered in rbenv-help is when `type -p gawk awk` is piped to `head`. Since the output of `type | head` is used as the command, occasionally the ouput is an error message about the broken pipe, rather than the expected `gawk`/`awk` command to use.