### PR TITLE
Updated Mac OSX brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ manager on Mac OS X:
 
 ~~~
 $ brew update
-$ brew install rbenv ruby-build
+$ brew install rbenv
 ~~~
 
 Afterwards you'll still need to add `eval "$(rbenv init -)"` to your


### PR DESCRIPTION
It seems rbenv now comes with ruby-build.  I have not investigated fully, but the previously shown command: `brew install rbenv ruby-build` caused issues on my machine.  After uninstalling both and simply running `brew install rbenv` everything worked fine.