### PR TITLE
libexec/rbenv: do not cd for path without dir

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -36,17 +36,23 @@ else
   }
 
   abs_dirname() {
-    local cwd="$PWD"
     local path="$1"
+    local save_cwd="$PWD"
+    local dir name
 
-    while [ -n "$path" ]; do
-      cd "${path%/*}"
-      local name="${path##*/}"
+    while [[ -n "$path" ]]; do
+      dir="${path%/*}"
+      if [[ "$dir" != "$path" ]]; then
+        cd "$dir"
+        name="${path##*/}"
+      else
+        name="$path"
+      fi
       path="$(resolve_link "$name" || true)"
     done
 
-    pwd
-    cd "$cwd"
+    echo "$PWD"
+    cd "$save_cwd"
   }
 fi
 

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -28,8 +28,8 @@ if enable -f "${BASH_SOURCE%/*}"/../libexec/rbenv-realpath.dylib realpath 2>/dev
 else
   [ -z "$RBENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
 
-  READLINK=$(type -p greadlink readlink | head -1)
-  [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
+  READLINK=$(type -p greadlink || type -p readlink \
+    || abort 'cannot find greadlink/readlink - are you missing GNU coreutils?')
 
   resolve_link() {
     $READLINK "$1"

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -74,3 +74,12 @@ load test_helper
   run rbenv echo "RBENV_HOOK_PATH"
   assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME%/*}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 }
+
+@test "abs_dirname with symlink in same dir" {
+  mkdir -p "$RBENV_TEST_DIR"
+  cd "$RBENV_TEST_DIR"
+  ln -s $(which rbenv) rbenv-wrapper
+  ln -s rbenv-wrapper rbenv-wrapper-link
+  run ./rbenv-wrapper-link echo "PATH"
+  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+}

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -84,3 +84,13 @@ load test_helper
   assert_output "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
   assert_success
 }
+
+@test "missing readlink" {
+  PATH="$(path_without greadlink readlink)" run rbenv which readlink
+  if [[ -z "$RBENV_NATIVE_EXT" ]]; then
+    assert_output "rbenv: cannot find greadlink/readlink - are you missing GNU coreutils?"
+    assert_failure
+  else
+    assert_failure "rbenv: readlink: command not found"
+  fi
+}

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -81,5 +81,6 @@ load test_helper
   ln -s $(which rbenv) rbenv-wrapper
   ln -s rbenv-wrapper rbenv-wrapper-link
   run ./rbenv-wrapper-link echo "PATH"
-  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+  assert_output "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+  assert_success
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -76,13 +76,18 @@ load test_helper
 }
 
 @test "abs_dirname with symlink in same dir" {
-  mkdir -p "$RBENV_TEST_DIR"
-  cd "$RBENV_TEST_DIR"
-  ln -s $(which rbenv) rbenv-wrapper
-  ln -s rbenv-wrapper rbenv-wrapper-link
-  run ./rbenv-wrapper-link echo "PATH"
-  assert_output "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
-  assert_success
+  # Only test this without realpath.dylib, since otherwise BASH_SOURCE would
+  # need to get resolved using the fallback method first.
+  if [[ -z "$RBENV_NATIVE_EXT" ]]; then
+    mkdir -p "$RBENV_TEST_DIR"
+    cd "$RBENV_TEST_DIR"
+    pwd
+    ln -s $(which rbenv) rbenv-wrapper
+    ln -s rbenv-wrapper rbenv-wrapper-link
+    run ./rbenv-wrapper-link echo "PATH"
+    assert_output "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+    assert_success
+  fi
 }
 
 @test "missing readlink" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -108,24 +108,27 @@ assert() {
   fi
 }
 
-# Output a modified PATH that ensures that the given executable is not present,
-# but in which system utils necessary for rbenv operation are still available.
+# Output a modified PATH that ensures that the given executable(s) are not
+# present, but in which system utils necessary for rbenv operation are still
+# available.
 path_without() {
-  local exe="$1"
+  local exe
   local path=":${PATH}:"
   local found alt util
-  for found in $(which -a "$exe"); do
-    found="${found%/*}"
-    if [ "$found" != "${RBENV_ROOT}/shims" ]; then
-      alt="${RBENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
-      mkdir -p "$alt"
-      for util in bash head cut readlink greadlink; do
-        if [ -x "${found}/$util" ]; then
-          ln -s "${found}/$util" "${alt}/$util"
-        fi
-      done
-      path="${path/:${found}:/:${alt}:}"
-    fi
+  for exe in $@; do
+    for found in $(which -a "$exe" 2>/dev/null); do
+      found="${found%/*}"
+      if [ "$found" != "${RBENV_ROOT}/shims" ]; then
+        alt="${RBENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"
+        mkdir -p "$alt"
+        for util in bash head cut readlink greadlink; do
+          if [[ "$util" != "$exe" ]] && [[ -x "${found}/$util" ]]; then
+            ln -s "${found}/$util" "${alt}/$util"
+          fi
+        done
+        path="${path/:${found}:/:${alt}:}"
+      fi
+    done
   done
   path="${path#:}"
   echo "${path%:}"


### PR DESCRIPTION
Without this patch you would see the following error for a symlink like
"/usr/bin/asciidoc -> asciidoc.py":

> …/libexec/{py,rb}env: line 43: cd: asciidoc.py: Not a directory
