### PR TITLE
Fish shell "." is deprecated in favor of "source"

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -70,7 +70,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and . (rbenv init -|psub)'
+      echo 'status --is-interactive; and source (rbenv init -|psub)'
       ;;
     * )
       echo 'eval "$(rbenv init -)"'
@@ -97,10 +97,7 @@ esac
 
 completion="${root}/completions/rbenv.${shell}"
 if [ -r "$completion" ]; then
-  case "$shell" in
-  fish ) echo ". '$completion'" ;;
-  *    ) echo "source '$completion'" ;;
-  esac
+  echo "source '$completion'"
 fi
 
 if [ -z "$no_rehash" ]; then
@@ -117,7 +114,7 @@ function rbenv
 
   switch "\$command"
   case ${commands[*]}
-    . (rbenv "sh-\$command" \$argv|psub)
+    source (rbenv "sh-\$command" \$argv|psub)
   case '*'
     command rbenv "\$command" \$argv
   end

--- a/test/init.bats
+++ b/test/init.bats
@@ -47,13 +47,13 @@ OUT
   root="$(cd $BATS_TEST_DIRNAME/.. && pwd)"
   run rbenv-init - fish
   assert_success
-  assert_line ". '${root}/test/../libexec/../completions/rbenv.fish'"
+  assert_line "source '${root}/test/../libexec/../completions/rbenv.fish'"
 }
 
 @test "fish instructions" {
   run rbenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'status --is-interactive; and . (rbenv init -|psub)'
+  assert_line 'status --is-interactive; and source (rbenv init -|psub)'
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
Per [the fish documentation for "source"](http://fishshell.com/docs/current/commands.html#source):

```
(a single period) is an alias for the source command. The use of . is deprecated in favour of source, and . will be removed in a future version of fish."
```
