### PR TITLE
Remove references to .rbenv/bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ easy to fork and contribute any changes back upstream.
     $ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
     ~~~
 
+    Then restart your terminal or reload your profile with `source ~/.bash_profile`.
+
     **Ubuntu Desktop note**: Modify your `~/.bashrc` instead of `~/.bash_profile`.
 
     **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ easy to fork and contribute any changes back upstream.
 
     **Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
 
-3. Run `~/.rbenv/bin/rbenv init` for shell-specific instructions on how to
+3. Run `rbenv init` for shell-specific instructions on how to
    initialize rbenv to enable shims and autocompletion.
 
 4. Restart your shell so that PATH changes take effect. (Opening a new


### PR DESCRIPTION
:warning: I'm not an rbenv user, so this may be dumb :warning: 

Helping a student debug their Ruby environment this week, I ran into this issue trying to configure rbenv. The docs indicate that I need to run an init command, but no `bin/` directory exists in the rbenv installation. Running `rbenv init` instead seems to work and give us the further instructions we needed.

I'm happy to patch this up further if more is needed. Thanks!