### PR TITLE
Adding check to make sure PATH variable is not populated multiple times.

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -71,9 +71,9 @@ shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
-  PATH="${plugin_bin}:${PATH}"
+  [[ ":${PATH}:" == *":${plugin_bin}:"* ]] || export PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+[[ ":${PATH}:" == *":${bin_path}:"* ]] || export PATH="${bin_path}:${PATH}"
 
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d"
 if [ "${bin_path%/*}" != "$RBENV_ROOT" ]; then


### PR DESCRIPTION
Add check to make sure that PATH isn't altered multiple times (e.g. once at login, a second time on tmux/screen shell, etc).