### PR TITLE
silence stdout when cding to working directory

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-export -n CDPATH
+unset CDPATH
 
 if [ "$1" = "--debug" ]; then
   export RBENV_DEBUG=1


### PR DESCRIPTION
I noticed an issue where the working directory was bring printed to STDOUT when running a script from outside the directory.

Here's more detail.

Given this project structure:

```
.
└── bin
    └── rubyscript
```

and the file `bin/rubyprogram` contains:

```ruby
#!/usr/bin/env ruby
puts "hi"
```

I see this in the console when I run the program from outside, then inside the `bin` directory.

```
$ bin/rubyprogram
/Users/mike/projects/ruby-script/bin
hi
$ cd ./bin
$ ./rubyprogram
hi
```

This PR fixes the issue.