### PR TITLE
Prevent duplicate ~/.rbenv/shims in $PATH

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -86,11 +86,11 @@ mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
+  echo "contains '$RBENV_ROOT/shims' \$PATH; or setenv PATH '$RBENV_ROOT/shims' \$PATH"
   echo "setenv RBENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  echo "[ \"\${PATH#*$RBENV_ROOT}\" != \"\$PATH\" ] || export PATH='$RBENV_ROOT/shims':\$PATH"
   echo "export RBENV_SHELL=$shell"
 ;;
 esac


### PR DESCRIPTION
Note fish does not like ${var} notation, and here I use the POSIX
substring parameter expansion to test if $RBENV_ROOT is a substring of
$PATH.

It does not work for csh but that's an existing problem and should be
fixed separately.