### PR TITLE
"." has been deprecated in the fish shell in favor of explicit "source"

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -70,7 +70,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and . (rbenv init -|psub)'
+      echo 'status --is-interactive; and source (rbenv init -|psub)'
       ;;
     * )
       echo 'eval "$(rbenv init -)"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -53,7 +53,7 @@ OUT
 @test "fish instructions" {
   run rbenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'status --is-interactive; and . (rbenv init -|psub)'
+  assert_line 'status --is-interactive; and source (rbenv init -|psub)'
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
see [this pullreq](https://github.com/yyuu/pyenv/pull/615#issuecomment-222333903)
