### PR TITLE
Help message should not be written to stdout for `sh-` commands

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -109,7 +109,11 @@ case "$command" in
 
   shift 1
   if [ "$1" = --help ]; then
-    exec rbenv-help "$command"
+    if [[ "$command" == "sh-"* ]]; then
+      exec rbenv-help "$command" 1>&2
+    else
+      exec rbenv-help "$command"
+    fi
   else
     exec "$command_path" "$@"
   fi

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -110,7 +110,7 @@ case "$command" in
   shift 1
   if [ "$1" = --help ]; then
     if [[ "$command" == "sh-"* ]]; then
-      exec rbenv-help "$command" 1>&2
+      echo "rbenv help \"$command\""
     else
       exec rbenv-help "$command"
     fi


### PR DESCRIPTION
`rbenv shell --help` is broken since it tries to write help messages on stdout. stdout for `sh-` commands should be shell commands though.

```
% rbenv shell --help
(eval):2: parse error near `\n'
```

As a workaround, this patch will redirect help messages to stderr instead of stdout.
