### PR TITLE
Add a workaround system executable in `/bin`

### DIFF
--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -24,7 +24,8 @@ fi
 if [ "$RBENV_VERSION" = "system" ]; then
   if RUBY_PATH="$(rbenv-which ruby 2>/dev/null)"; then
     RUBY_PATH="${RUBY_PATH%/*}"
-    echo "${RUBY_PATH%/bin}"
+    RBENV_PREFIX_PATH="${RUBY_PATH%/bin}"
+    echo "${RBENV_PREFIX_PATH:-/}"
     exit
   else
     echo "rbenv: system version not found in PATH" >&2

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -25,12 +25,13 @@ load test_helper
 }
 
 @test "prefix for system in /" {
-  mkdir -p "${RBENV_TEST_DIR}/bin"
-  touch "${RBENV_TEST_DIR}/bin/rbenv-which"
-  echo "echo /bin/ruby" >"${RBENV_TEST_DIR}/bin/rbenv-which"
-  chmod +x "${RBENV_TEST_DIR}/bin/rbenv-which"
+  mkdir -p "${BATS_TEST_DIRNAME}/libexec"
+  touch "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
+  echo "echo /bin/ruby" >"${BATS_TEST_DIRNAME}/libexec/rbenv-which"
+  chmod +x "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   RBENV_VERSION="system" run rbenv-prefix
   assert_success "/"
+  rm -f "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
 }
 
 @test "prefix for invalid system" {

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -26,7 +26,6 @@ load test_helper
 
 @test "prefix for system in /" {
   mkdir -p "${BATS_TEST_DIRNAME}/libexec"
-  touch "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   echo "echo /bin/ruby" >"${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   chmod +x "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   RBENV_VERSION="system" run rbenv-prefix

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -26,7 +26,9 @@ load test_helper
 
 @test "prefix for system in /" {
   mkdir -p "${BATS_TEST_DIRNAME}/libexec"
-  echo "echo /bin/ruby" >"${BATS_TEST_DIRNAME}/libexec/rbenv-which"
+  { echo "#!/bin/sh"
+    echo "echo /bin/ruby"
+  } >"${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   chmod +x "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   RBENV_VERSION="system" run rbenv-prefix
   assert_success "/"

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -24,6 +24,15 @@ load test_helper
   assert_success "$RBENV_TEST_DIR"
 }
 
+@test "prefix for system in /" {
+  mkdir -p "${RBENV_TEST_DIR}/bin"
+  touch "${RBENV_TEST_DIR}/bin/rbenv-which"
+  echo "echo /bin/ruby" >"${RBENV_TEST_DIR}/bin/rbenv-which"
+  chmod +x "${RBENV_TEST_DIR}/bin/rbenv-which"
+  RBENV_VERSION="system" run rbenv-prefix
+  assert_success "/"
+}
+
 @test "prefix for invalid system" {
   PATH="$(path_without ruby)" run rbenv-prefix system
   assert_failure "rbenv: system version not found in PATH"

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -26,9 +26,10 @@ load test_helper
 
 @test "prefix for system in /" {
   mkdir -p "${BATS_TEST_DIRNAME}/libexec"
-  { echo "#!/bin/sh"
-    echo "echo /bin/ruby"
-  } >"${BATS_TEST_DIRNAME}/libexec/rbenv-which"
+  cat >"${BATS_TEST_DIRNAME}/libexec/rbenv-which" <<OUT
+#!/bin/sh
+echo /bin/ruby
+OUT
   chmod +x "${BATS_TEST_DIRNAME}/libexec/rbenv-which"
   RBENV_VERSION="system" run rbenv-prefix
   assert_success "/"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -20,10 +20,10 @@ if [ -z "$RBENV_TEST_DIR" ]; then
   export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+  PATH="${RBENV_TEST_DIR}/bin:$PATH"
   PATH="${BATS_TEST_DIRNAME}/../libexec:$PATH"
   PATH="${BATS_TEST_DIRNAME}/libexec:$PATH"
   PATH="${RBENV_ROOT}/shims:$PATH"
-  PATH="${RBENV_TEST_DIR}/bin:$PATH"
   export PATH
 
   for xdg_var in `env 2>/dev/null | grep ^XDG_ | cut -d= -f1`; do unset "$xdg_var"; done

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -20,10 +20,10 @@ if [ -z "$RBENV_TEST_DIR" ]; then
   export RBENV_HOOK_PATH="${RBENV_ROOT}/rbenv.d"
 
   PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
-  PATH="${RBENV_TEST_DIR}/bin:$PATH"
   PATH="${BATS_TEST_DIRNAME}/../libexec:$PATH"
   PATH="${BATS_TEST_DIRNAME}/libexec:$PATH"
   PATH="${RBENV_ROOT}/shims:$PATH"
+  PATH="${RBENV_TEST_DIR}/bin:$PATH"
   export PATH
 
   for xdg_var in `env 2>/dev/null | grep ^XDG_ | cut -d= -f1`; do unset "$xdg_var"; done


### PR DESCRIPTION
It seems that `rbenv-prefix` doesn't work well if the `system` executable is installed in `/` (`/bin`).