### PR TITLE
Fixed `rbenv init -` output to work w/ no args and bash's `set -u`.

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -138,7 +138,7 @@ esac
 if [ "$shell" != "fish" ]; then
 IFS="|"
 cat <<EOS
-  command="\$1"
+  command="\${1:-}"
   if [ "\$#" -gt 0 ]; then
     shift
   fi


### PR DESCRIPTION
If you use `set -u` in your bash setup (error on uninitialized vars) then `rbenv` will fail w/ no args because `$1` is used and unset. This fixes that.

I have not attempted to root out any others yet.