### PR TITLE
Fix fish subcommand completion

### DIFF
--- a/completions/rbenv.fish
+++ b/completions/rbenv.fish
@@ -18,5 +18,6 @@ end
 
 complete -f -c rbenv -n '__fish_rbenv_needs_command' -a '(rbenv commands)'
 for cmd in (rbenv commands)
-  complete -f -c rbenv -n "__fish_rbenv_using_command $cmd" -a "(rbenv completions $cmd)"
+  complete -f -c pyenv -n "__fish_pyenv_using_command $cmd" -a \
+    "(rbenv completions (commandline -opc)[2..-1])"
 end

--- a/completions/rbenv.fish
+++ b/completions/rbenv.fish
@@ -18,6 +18,6 @@ end
 
 complete -f -c rbenv -n '__fish_rbenv_needs_command' -a '(rbenv commands)'
 for cmd in (rbenv commands)
-  complete -f -c pyenv -n "__fish_pyenv_using_command $cmd" -a \
+  complete -f -c rbenv -n "__fish_rbenv_using_command $cmd" -a \
     "(rbenv completions (commandline -opc)[2..-1])"
 end


### PR DESCRIPTION
This allows subcommand style plugins to properly autocomplete.
Existing commands are not affected. 

Example, say you have support for `rbenv foo bar --flag`, then
this allows the last `--flag` argument to be properly completed.

See also https://github.com/yyuu/pyenv/pull/831