### PR TITLE
Better error message for `rbenv shell`

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -106,7 +106,13 @@ case "$command" in
   ;;
 * )
   command_path="$(command -v "rbenv-$command" || true)"
-  [ -n "$command_path" ] || abort "no such command \`$command'"
+  if [ -z "$command_path" ]; then
+    if [ "$command" == "shell" ]; then
+      abort "shell integration not enabled. Run \`rbenv init' for instructions."
+    else
+      abort "no such command \`$command'"
+    fi
+  fi
 
   shift 1
   if [ "$1" = --help ]; then

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -2,6 +2,17 @@
 
 load test_helper
 
+@test "shell integration disabled" {
+  run rbenv shell
+  assert_failure "rbenv: shell integration not enabled. Run \`rbenv init' for instructions."
+}
+
+@test "shell integration enabled" {
+  eval "$(rbenv init -)"
+  run rbenv shell
+  assert_success "rbenv: no shell-specific version configured"
+}
+
 @test "no shell version" {
   mkdir -p "${RBENV_TEST_DIR}/myproject"
   cd "${RBENV_TEST_DIR}/myproject"


### PR DESCRIPTION
Shell integration is not enabled by default. This means that, from all the commands from `rbenv commands`, only "shell" won't work right away.

Replace "no such command" with a more descriptive message that points to `rbenv init` instead.