### PR TITLE
partly resolve #759

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -16,7 +16,7 @@ mkdir -p "$SHIM_PATH"
 # to stderr and exit with a non-zero status.
 set -o noclobber
 { echo > "$PROTOTYPE_SHIM_PATH"
-} 2>/dev/null ||
+} 2>| /dev/null ||
 { if [ -w "$SHIM_PATH" ]; then
     echo "rbenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
   else


### PR DESCRIPTION
- some versions of bash (e.g. 4.3.11) complain about clobbering
  /dev/null, use bash's explicit >| operator to ignore noclober
- not sure if the original #759 report has the same cause
- https://github.com/rbenv/rbenv/issues/759#issuecomment-289326891