### PR TITLE
Don't unset CDPATH

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -60,6 +60,7 @@ export RBENV_ROOT
 if [ -z "${RBENV_DIR}" ]; then
   RBENV_DIR="$PWD"
 else
+  [[ $RBENV_DIR == /* ]] || RBENV_DIR=$PWD/$RBENV_DIR
   cd "$RBENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$RBENV_DIR'"
   RBENV_DIR="$PWD"
   cd "$OLDPWD"

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-unset CDPATH
 
 if [ "$1" = "--debug" ]; then
   export RBENV_DEBUG=1


### PR DESCRIPTION
I strongly feel that unsetting `CDPATH` was an overreaction to an easily addressed edge case, and have practical reasons for wanting to get it restored. I know this is a contentious issue, so here's a comprehensive analysis of the 5 uses (9 invocations) of `cd` in `libexec`.

* [`abs_dirname` in `rbenv`](https://github.com/rbenv/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv#L38--50), which is only ever [called on `$0`](https://github.com/rbenv/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv#L72), which is absolute unless you do something like `cd ~/.rbenv; bin/rbenv` (can be fixed if it's an actual problem).
* [`$RBENV_DIR` in `rbenv`](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/bin/rbenv#L63), the culprit from #866 which provoked the unset. Addressed in this PR.
* [`${BASH_SOURCE%/*}` in `rbenv---version`](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv---version#L18), which will [be absolute when called by `rbenv`](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/bin/rbenv#L107-L119).
* [`realpath` in `rbenv-hooks`](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv-hooks#L39-L52), which is only ever called on [an absolute hook directory](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv-hooks#L55-L63).
* [`realpath` in `rbenv-versions`](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv-versions#L46-L59), which is only ever called on [an absolute version directory](https://github.com/sstephenson/rbenv/blob/4f8925abe7e4b373156bba9cc5310e8e0d04a28a/libexec/rbenv-versions#L62-L64).

That just leaves plugins. In my humble opinion, plugins can `unset CDPATH` themselves if need be, but if that's a sticking point, let me know, and maybe we can compromise on leaving `CDPATH` in place for `rbenv-exec`, or something.