### PR TITLE
Prefer 'set' over 'setenv' for fish shell

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -86,8 +86,8 @@ mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
-  echo "setenv RBENV_SHELL $shell"
+  echo 'set -gx PATH '${RBENV_ROOT}'/shims $PATH'
+  echo "set -gx RBENV_SHELL $shell"
 ;;
 * )
   echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -86,7 +86,7 @@ mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo 'set -gx PATH '${RBENV_ROOT}'/shims $PATH'
+  echo "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
   echo "set -gx RBENV_SHELL $shell"
 ;;
 * )

--- a/test/init.bats
+++ b/test/init.bats
@@ -73,7 +73,7 @@ OUT
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run rbenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
@@ -87,7 +87,7 @@ OUT
   export PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${RBENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {


### PR DESCRIPTION
The setenv function in fish shell has changed dramatically in
https://github.com/fish-shell/fish-shell/commit/75600b6b538f242a6b340e51965f25cfd4473c4a
It now conforms to the csh version, which takes at most two arguments.
In this init script, the form
    setenv PATH prepend_something $PATH
had been used, which had too many arguments.
Since setenv isn't a native command in fish, a suitable replacement is
to use the "set -gx" command, which can consume multiple arguments.