### PR TITLE
Make homebrew installation instructions more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ manager on Mac OS X:
 ~~~
 $ brew update
 $ brew install rbenv
+$ rbenv init
 ~~~
 
-Afterwards you'll still need to run `rbenv init` for instructions
-as stated in the caveats. You'll only ever have to do this once.
+You'll only ever have to run `rbenv init` once.
 
 ### How rbenv hooks into your shell
 


### PR DESCRIPTION
I work on a team that has followed the Homebrew installations. More than once we've missed the `rbenv init` instruction and it has caused headaches down the road. This formatting makes it harder to miss.