### PR TITLE
Fixed support for commas for all environment variables in configure script

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -34,16 +34,16 @@ esac
 eval "$("$src_dir"/shobj-conf -C "$CC" -o "$host_os")"
 
 sed "
-  s,@CC@,${CC},
-  s,@CFLAGS@,${CFLAGS//,/\\,},
-  s,@LOCAL_CFLAGS@,${LOCAL_CFLAGS//,/\\,},
-  s,@DEFS@,${DEFS},
-  s,@LOCAL_DEFS@,${LOCAL_DEFS},
-  s,@SHOBJ_CC@,${SHOBJ_CC},
-  s,@SHOBJ_CFLAGS@,${SHOBJ_CFLAGS//,/\\,},
-  s,@SHOBJ_LD@,${SHOBJ_LD},
-  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\\,},
-  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\\,},
-  s,@SHOBJ_LIBS@,${SHOBJ_LIBS},
-  s,@SHOBJ_STATUS@,${SHOBJ_STATUS},
+  s#@CC@#${CC}#
+  s#@CFLAGS@#${CFLAGS}#
+  s#@LOCAL_CFLAGS@#${LOCAL_CFLAGS}#
+  s#@DEFS@#${DEFS}#
+  s#@LOCAL_DEFS@#${LOCAL_DEFS}#
+  s#@SHOBJ_CC@#${SHOBJ_CC}#
+  s#@SHOBJ_CFLAGS@#${SHOBJ_CFLAGS}#
+  s#@SHOBJ_LD@#${SHOBJ_LD}#
+  s#@SHOBJ_LDFLAGS@#${SHOBJ_LDFLAGS}#
+  s#@SHOBJ_XLDFLAGS@#${SHOBJ_XLDFLAGS}#
+  s#@SHOBJ_LIBS@#${SHOBJ_LIBS}#
+  s#@SHOBJ_STATUS@#${SHOBJ_STATUS}#
 " "$src_dir"/Makefile.in > "$src_dir"/Makefile


### PR DESCRIPTION
Hi! Currently in configure script comma used as a separator in sed command. Sed allows using any character as a separator. I recommend using number sign (`#`) as a separator. In this case, we don't need to escape the commas in environment variables.