### PR TITLE
use absolute path to rbenv and check if PATH was already extended

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -90,7 +90,7 @@ fish )
   echo "set -gx RBENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  echo ":${PATH}:" | grep -q ":${RBENV_ROOT}/shims:" || echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
   echo "export RBENV_SHELL=$shell"
 ;;
 esac
@@ -145,9 +145,9 @@ cat <<EOS
 
   case "\$command" in
   ${commands[*]})
-    eval "\$(rbenv "sh-\$command" "\$@")";;
+    eval "\$($RBENV_ROOT/bin/rbenv "sh-\$command" "\$@")";;
   *)
-    command rbenv "\$command" "\$@";;
+    $RBENV_ROOT/bin/rbenv "\$command" "\$@";;
   esac
 }
 EOS


### PR DESCRIPTION
I noticed that rbenv-init doesn't check if ${RBENV_ROOT}/shims is already added to the PATH, this is fixed on line 93.

In order to use rbenv I have to create symlink in $HOME/bin to ${RBENV_ROOT}/bin/rbenv. With fix on lines 148 and 150 this is not needed any more. I can have
```
eval "$(${RBENV_ROOT}/bin/rbenv init -)"
```
in my .bashrc instead of 
```
eval "$(rbenv init -)"
```
and there will be no need to create symlink.