### PR TITLE
Ignore empty `.ruby-version` files

### DIFF
--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -9,7 +9,7 @@ target_dir="$1"
 find_local_version_file() {
   local root="$1"
   while ! [[ "$root" =~ ^//[^/]*$ ]]; do
-    if [ -f "${root}/.ruby-version" ]; then
+    if [ -s "${root}/.ruby-version" ]; then
       echo "${root}/.ruby-version"
       return 0
     fi

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -9,7 +9,7 @@ setup() {
 
 create_file() {
   mkdir -p "$(dirname "$1")"
-  touch "$1"
+  echo "system" > "$1"
 }
 
 @test "detects global 'version' file" {

--- a/test/version-origin.bats
+++ b/test/version-origin.bats
@@ -26,7 +26,7 @@ setup() {
 }
 
 @test "detects local file" {
-  touch .ruby-version
+  echo "system" > .ruby-version
   run rbenv-version-origin
   assert_success "${PWD}/.ruby-version"
 }


### PR DESCRIPTION
This PR addresses https://github.com/rbenv/rbenv/issues/1065.

Command `rbenv version-name > .ruby-version` will create an empty `.ruby-version` file
before running `rbenv-version-file`. This causes `rbenv-version-file` to return an empty
string which in turn causes `rbenv-version-name` to return `system`.

Ensure file size of `.ruby-version` is non-zero as a workaround.

**This fix will cause problem for users that use empty `.ruby-version` to point to `system` ruby.**