### PR TITLE
Wait rehash until lock acquisition

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -40,7 +40,7 @@ if [ ! -w "$SHIM_PATH" ]; then
 fi
 
 unset acquired
-for _ in $(seq "${RBENV_REHASH_TIMEOUT:-60}"); do
+for (( i=1; i<="${RBENV_REHASH_TIMEOUT:-60}"; i++ )); do
   if acquire_lock 2>/dev/null; then
     acquired=1
     break

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -10,29 +10,50 @@ PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.rbenv-shim"
 # Create the shims directory if it doesn't already exist.
 mkdir -p "$SHIM_PATH"
 
-# Ensure only one instance of rbenv-rehash is running at a time by
-# setting the shell's `noclobber` option and attempting to write to
-# the prototype shim file. If the file already exists, print a warning
-# to stderr and exit with a non-zero status.
-set -o noclobber
-{ echo > "$PROTOTYPE_SHIM_PATH"
-} 2>| /dev/null ||
-{ if [ -w "$SHIM_PATH" ]; then
-    echo "rbenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
-  else
-    echo "rbenv: cannot rehash: $SHIM_PATH isn't writable"
-  fi
-  exit 1
-} >&2
-set +o noclobber
+acquire_lock() {
+  # Ensure only one instance of rbenv-rehash is running at a time by
+  # setting the shell's `noclobber` option and attempting to write to
+  # the prototype shim file. If the file already exists, print a warning
+  # to stderr and exit with a non-zero status.
+  local ret
+  set -o noclobber
+  echo > "$PROTOTYPE_SHIM_PATH" 2>| /dev/null || ret=1
+  set +o noclobber
+  [ -z "${ret}" ]
+}
 
 # If we were able to obtain a lock, register a trap to clean up the
 # prototype shim when the process exits.
-trap remove_prototype_shim EXIT
+trap release_lock EXIT
 
 remove_prototype_shim() {
   rm -f "$PROTOTYPE_SHIM_PATH"
 }
+
+release_lock() {
+  remove_prototype_shim
+}
+
+if [ ! -w "$SHIM_PATH" ]; then
+  echo "rbenv: cannot rehash: $SHIM_PATH isn't writable"
+  exit 1
+fi
+
+unset acquired
+for _ in $(seq "${RBENV_REHASH_TIMEOUT:-60}"); do
+  if acquire_lock 2>/dev/null; then
+    acquired=1
+    break
+  else
+    # POSIX sleep(1) doesn't provides time precision of subsecond
+    sleep 1
+  fi
+done
+
+if [ -z "${acquired}" ]; then
+  echo "rbenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
+  exit 1
+fi
 
 # The prototype shim file is a script that re-execs itself, passing
 # its filename and any arguments to `rbenv exec`. This file is

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -25,10 +25,20 @@ create_executable() {
 }
 
 @test "rehash in progress" {
+  export RBENV_REHASH_TIMEOUT=1
   mkdir -p "${RBENV_ROOT}/shims"
   touch "${RBENV_ROOT}/shims/.rbenv-shim"
   run rbenv-rehash
   assert_failure "rbenv: cannot rehash: ${RBENV_ROOT}/shims/.rbenv-shim exists"
+}
+
+@test "wait until lock acquisition" {
+  export RBENV_REHASH_TIMEOUT=5
+  mkdir -p "${RBENV_ROOT}/shims"
+  touch "${RBENV_ROOT}/shims/.rbenv-shim"
+  bash -c "sleep 1 && rm -f ${RBENV_ROOT}/shims/.rbenv-shim" &
+  run rbenv-rehash
+  assert_success
 }
 
 @test "creates shims" {


### PR DESCRIPTION
rbenv and ruby-build are both implemented to call rehash inside its code on some circumstances. However, since the rehash is implemented to fail if there're another concurrent rehash process within the same `$RBENV_ROOT`, all these implementations cannot run in parallel.

In general, rehash will finish within a second for most cases. It'd mean that just adding some extra lock wait of few seconds will help improving concurrency of these rehash related commands without introducing other external lock. (AFAIK, some external tool like Jenkins' [rbenv-plugin is using some external lock](https://github.com/jenkinsci/rbenv-plugin/blob/v0.0.16/lib/rbenv/semaphore.rb#L25) as a workaround for the concurrent rehash issue)

I've implemented some retry mechanism based on current code of `noclobber` based locking. It will retry up to 60 seconds until acquisition of the _lock file_.

See also:
* https://github.com/pyenv/pyenv/pull/1145