### PR TITLE
libexec/rbenv: skip `cd`s

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -61,9 +61,9 @@ if [ -z "${RBENV_DIR}" ]; then
   RBENV_DIR="$PWD"
 else
   [[ $RBENV_DIR == /* ]] || RBENV_DIR="$PWD/$RBENV_DIR"
-  cd "$RBENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$RBENV_DIR'"
-  RBENV_DIR="$PWD"
-  cd "$OLDPWD"
+fi
+if [ ! -d "$RBENV_DIR" ] || [ ! -e "$RBENV_DIR" ]; then
+  abort "cannot change working directory to \`$RBENV_DIR'"
 fi
 export RBENV_DIR
 


### PR DESCRIPTION
This appears to be done to get the resolved name for `$RBENV_DIR`, but
that is not really necessary.

This adds an explicit existence check instead, which also gets done for
`$PWD`, because it might not exist after all, too.