### PR TITLE
libexec/rbenv-exec: simplify/fix sourcing exec hooks

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -33,10 +33,7 @@ export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks exec`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do
+rbenv-hooks exec | while read -ra script; do
   source "$script"
 done
 

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for rbenv
 # Usage: eval "$(rbenv init - [--no-rehash] [<shell>])"
+# shellcheck disable=SC2016,SC2086,SC2088
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
@@ -104,7 +105,10 @@ if [ -z "$no_rehash" ]; then
   echo 'command rbenv rehash 2>/dev/null'
 fi
 
-commands=(`rbenv-commands --sh`)
+shell_commands=()
+while read -ra shell_command; do
+  shell_commands+=("$shell_command")
+done < <(rbenv-commands --sh)
 case "$shell" in
 fish )
   cat <<EOS
@@ -113,7 +117,7 @@ function rbenv
   set -e argv[1]
 
   switch "\$command"
-  case ${commands[*]}
+  case ${shell_commands[*]}
     source (rbenv "sh-\$command" \$argv|psub)
   case '*'
     command rbenv "\$command" \$argv
@@ -144,7 +148,7 @@ cat <<EOS
   fi
 
   case "\$command" in
-  ${commands[*]})
+  ${shell_commands[*]})
     eval "\$(rbenv "sh-\$command" "\$@")";;
   *)
     command rbenv "\$command" "\$@";;

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -141,11 +141,7 @@ make_shims $(list_executable_names | sort -u)
 
 
 # Allow plugins to register shims.
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks rehash`)
-IFS="$OLDIFS"
-
-for script in "${scripts[@]}"; do
+rbenv-hooks rehash | while read -ra script; do
   source "$script"
 done
 

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -8,10 +8,7 @@ if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks version-name`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do
+rbenv-hooks version-name | while read -ra script; do
   source "$script"
 done
 

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -5,10 +5,7 @@ set -e
 
 unset RBENV_VERSION_ORIGIN
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks version-origin`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do
+rbenv-hooks version-origin | while read -ra script; do
   source "$script"
 done
 

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -43,10 +43,7 @@ else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks which`)
-IFS="$OLDIFS"
-for script in "${scripts[@]}"; do
+rbenv-hooks which | while read -ra script; do
   source "$script"
 done
 


### PR DESCRIPTION
Fixes two issues reported by shellcheck:

    In libexec/rbenv-exec line 37:
    IFS=$'\n' scripts=(`rbenv-hooks exec`)
                       ^-- SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
                       ^-- SC2006: Use $(..) instead of legacy `..`.