### PR TITLE
rbenv-exec: do not add RBENV_BIN_PATH to PATH

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -41,7 +41,4 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-if [ "$RBENV_VERSION" != "system" ]; then
-  export PATH="${RBENV_BIN_PATH}:${PATH}"
-fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -81,21 +81,9 @@ OUT
 @test "supports ruby -S <cmd>" {
   export RBENV_VERSION="2.0"
 
-  # emulate `ruby -S' behavior
   create_executable "ruby" <<SH
 #!$BASH
-if [[ \$1 == "-S"* ]]; then
-  found="\$(PATH="\${RUBYPATH:-\$PATH}" which \$2)"
-  # assert that the found executable has ruby for shebang
-  if head -1 "\$found" | grep ruby >/dev/null; then
-    \$BASH "\$found"
-  else
-    echo "ruby: no Ruby script found in input (LoadError)" >&2
-    exit 1
-  fi
-else
-  echo 'ruby 2.0 (rbenv test)'
-fi
+echo "\$0 \$@"
 SH
 
   create_executable "rake" <<SH
@@ -105,5 +93,5 @@ SH
 
   rbenv-rehash
   run ruby -S rake
-  assert_success "hello rake"
+  assert_success "${RBENV_TEST_DIR}/root/versions/2.0/bin/ruby -S rake"
 }


### PR DESCRIPTION
This appears to have been added for "ruby -S" support (which looks up
the script name in $PATH).
But it looks like this should just get delegated to "ruby" itself.

Initially I've looked into looking for the file in the shim (when "-S"
is used), but it does not seem to be necessary after all.

I've looked into this when trying to fix the issues in pyenv that arise
from mangling the $PATH here.