### PR TITLE
Fix PATH mangling and do not use -a with exec

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -71,10 +71,11 @@ export RBENV_DIR
 shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
+export _RBENV_ORIG_PATH="$PATH"
 for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+PATH="${bin_path}:${PATH}"
 
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d"
 if [ "${bin_path%/*}" != "$RBENV_ROOT" ]; then

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -31,7 +31,6 @@ fi
 
 export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
-RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
 OLDIFS="$IFS"
 IFS=$'\n' scripts=(`rbenv-hooks exec`)
@@ -41,7 +40,4 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
-if [ "$RBENV_VERSION" != "system" ]; then
-  export PATH="${RBENV_BIN_PATH}:${PATH}"
-fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -40,4 +40,8 @@ for script in "${scripts[@]}"; do
 done
 
 shift 1
+if [ -n "$_RBENV_ORIG_PATH" ]; then
+  PATH="$_RBENV_ORIG_PATH"
+  unset _RBENV_ORIG_PATH
+fi
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -44,4 +44,4 @@ if [ -n "$_RBENV_ORIG_PATH" ]; then
   PATH="$_RBENV_ORIG_PATH"
   unset _RBENV_ORIG_PATH
 fi
-exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"
+exec "$RBENV_COMMAND_PATH" "$@"

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -14,6 +14,21 @@ create_executable() {
   chmod +x "${bin}/$name"
 }
 
+@test "does not change PATH for exec'ed commands" {
+  export RBENV_VERSION="2.0"
+  create_executable "ruby" <<SH
+#!$BASH
+echo \$PATH
+SH
+  rbenv-rehash
+
+  run rbenv-exec ruby
+  assert_success "$PATH"
+
+  run ruby
+  assert_success "$PATH"
+}
+
 @test "fails with invalid version" {
   export RBENV_VERSION="2.0"
   run rbenv-exec ruby -v

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -81,21 +81,9 @@ OUT
 @test "supports ruby -S <cmd>" {
   export RBENV_VERSION="2.0"
 
-  # emulate `ruby -S' behavior
   create_executable "ruby" <<SH
 #!$BASH
-if [[ \$1 == "-S"* ]]; then
-  found="\$(PATH="\${RUBYPATH:-\$PATH}" which \$2)"
-  # assert that the found executable has ruby for shebang
-  if head -1 "\$found" | grep ruby >/dev/null; then
-    \$BASH "\$found"
-  else
-    echo "ruby: no Ruby script found in input (LoadError)" >&2
-    exit 1
-  fi
-else
-  echo 'ruby 2.0 (rbenv test)'
-fi
+echo "\$0 \$@"
 SH
 
   create_executable "rake" <<SH
@@ -105,5 +93,5 @@ SH
 
   rbenv-rehash
   run ruby -S rake
-  assert_success "hello rake"
+  assert_success "${RBENV_TEST_DIR}/root/versions/2.0/bin/ruby -S rake"
 }


### PR DESCRIPTION
This stores the original $PATH in RBENV_ORIG_PATH and uses that when
`exec`ing the actual command.

Includes #1088 and https://github.com/rbenv/rbenv/pull/1090.