### PR TITLE
rbenv-exec: do not use `-a` with `exec`

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -44,4 +44,4 @@ shift 1
 if [ "$RBENV_VERSION" != "system" ]; then
   export PATH="${RBENV_BIN_PATH}:${PATH}"
 fi
-exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"
+exec "$RBENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Using the command name only causes an issue in pyenv, where Python then
uses the PATH to look up the full path for `sys.executable`.

Not using `-a` appears to result in the same behavior as using the full
command path (`$RBENV_COMMAND_PATH`), so just do not use it.
It has been there since the initial commit (99035a4).