### PR TITLE
rehash: shims: source rbenv-exec

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -61,7 +61,7 @@ if [ "\$program" = "ruby" ]; then
 fi
 
 export RBENV_ROOT="$RBENV_ROOT"
-exec "$(command -v rbenv)" exec "\$program" "\$@"
+source $RBENV_ROOT/libexec/rbenv-exec "\$program" "\$@"
 SH
   chmod +x "$PROTOTYPE_SHIM_PATH"
 }

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -103,6 +103,8 @@ SH
 echo hello rake
 SH
 
+  mkdir $RBENV_ROOT/libexec
+  cp -a $BATS_CWD/libexec/rbenv-exec $RBENV_ROOT/libexec
   rbenv-rehash
   run ruby -S rake
   assert_success "hello rake"


### PR DESCRIPTION
This avoids an unnecessary subshell for `command -v`, and sources
libexec/rbenv-exec instead of calling it through a new bash subprocess.