### PR TITLE
make rbenv init more visible in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,7 @@ If you're on macOS, we recommend installing rbenv with
     $ rbenv init
     ~~~
 
-   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell). 
-   This is the step that will make running `ruby` "see" the Ruby version that 
-   you choose with rbenv.
+   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell).
 
 3. Close your Terminal window and open a new one so your changes take
    effect.
@@ -257,10 +255,7 @@ a systemwide install.
    $ ~/.rbenv/bin/rbenv init
    ~~~
    
-   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell). 
-   This is the step that will make running `ruby` "see" the Ruby version that 
-   you choose with rbenv.
-
+   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell).
 
 4. Restart your shell so that PATH changes take effect. (Opening a new
    terminal tab will usually do it.)

--- a/README.md
+++ b/README.md
@@ -163,9 +163,15 @@ If you're on macOS, we recommend installing rbenv with
    Note that this also installs `ruby-build`, so you'll be ready to
    install other Ruby versions out of the box.
 
-2. Run `rbenv init` and follow the instructions to set up
-   rbenv integration with your shell. This is the step that will make
-   running `ruby` "see" the Ruby version that you choose with rbenv.
+2. Initialize rbenv.
+
+    ~~~ sh
+    $ rbenv init
+    ~~~
+
+   Follow the instructions to set up rbenv integration with your shell. This 
+   is the step that will make running `ruby` "see" the Ruby version that you
+   choose with rbenv.
 
 3. Close your Terminal window and open a new one so your changes take
    effect.
@@ -245,9 +251,15 @@ a systemwide install.
      $ set -Ux fish_user_paths $HOME/.rbenv/bin $fish_user_paths
      ~~~
 
-3. Run `~/.rbenv/bin/rbenv init` and follow the instructions to set up
-   rbenv integration with your shell. This is the step that will make
-   running `ruby` "see" the Ruby version that you choose with rbenv.
+3. Initialize rbenv.
+
+   ~~~ sh
+   $ ~/.rbenv/bin/rbenv init
+   ~~~
+   
+   Follow the instructions to set up rbenv integration with your shell. This 
+   is the step that will make running `ruby` "see" the Ruby version that you
+   choose with rbenv.
 
 4. Restart your shell so that PATH changes take effect. (Opening a new
    terminal tab will usually do it.)

--- a/README.md
+++ b/README.md
@@ -163,15 +163,15 @@ If you're on macOS, we recommend installing rbenv with
    Note that this also installs `ruby-build`, so you'll be ready to
    install other Ruby versions out of the box.
 
-2. Initialize rbenv.
+2. Set up rbenv in your shell.
 
     ~~~ sh
     $ rbenv init
     ~~~
 
-   Follow the instructions to set up rbenv integration with your shell. This 
-   is the step that will make running `ruby` "see" the Ruby version that you
-   choose with rbenv.
+   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell). 
+   This is the step that will make running `ruby` "see" the Ruby version that 
+   you choose with rbenv.
 
 3. Close your Terminal window and open a new one so your changes take
    effect.
@@ -251,15 +251,16 @@ a systemwide install.
      $ set -Ux fish_user_paths $HOME/.rbenv/bin $fish_user_paths
      ~~~
 
-3. Initialize rbenv.
+3. Set up rbenv in your shell.
 
    ~~~ sh
    $ ~/.rbenv/bin/rbenv init
    ~~~
    
-   Follow the instructions to set up rbenv integration with your shell. This 
-   is the step that will make running `ruby` "see" the Ruby version that you
-   choose with rbenv.
+   Follow the printed instructions to [set up rbenv shell integration](#how-rbenv-hooks-into-your-shell). 
+   This is the step that will make running `ruby` "see" the Ruby version that 
+   you choose with rbenv.
+
 
 4. Restart your shell so that PATH changes take effect. (Opening a new
    terminal tab will usually do it.)


### PR DESCRIPTION
In these two places where the reader is instructed to run `rbenv init` the command is not broken out from the text like nearly all of the other shell commands. This makes it easy for a reader to miss or misunderstand that `rbenv init` should be run in shell.

I moved them into a position such that they are now harder to miss and consistent with the rest of the document. Let me know if there are other changes I should make.

Thanks.