### PR TITLE
rbenv-which: change PATH only for the "command -v" lookup

### DIFF
--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -37,8 +37,8 @@ fi
 RBENV_VERSION="${RBENV_VERSION:-$(rbenv-version-name)}"
 
 if [ "$RBENV_VERSION" = "system" ]; then
-  PATH="$(remove_from_path "${RBENV_ROOT}/shims")"
-  RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
+  PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \
+    RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
 else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi


### PR DESCRIPTION
This is not really necessary, because rbenv-which is used in a subshell
currently, but makes a difference if rbenv-which would be sourced.