### PR TITLE
rbenv-prefix: do not silence rbenv-which for system version

### DIFF
--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -22,7 +22,7 @@ elif [ -z "$RBENV_VERSION" ]; then
 fi
 
 if [ "$RBENV_VERSION" = "system" ]; then
-  if RUBY_PATH="$(rbenv-which ruby 2>/dev/null)"; then
+  if RUBY_PATH="$(rbenv-which ruby)"; then
     RUBY_PATH="${RUBY_PATH%/*}"
     RBENV_PREFIX_PATH="${RUBY_PATH%/bin}"
     echo "${RBENV_PREFIX_PATH:-/}"

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -38,5 +38,8 @@ OUT
 
 @test "prefix for invalid system" {
   PATH="$(path_without ruby)" run rbenv-prefix system
-  assert_failure "rbenv: system version not found in PATH"
+  assert_failure <<EOF
+rbenv: ruby: command not found
+rbenv: system version not found in PATH"
+EOF
 }


### PR DESCRIPTION
This suppressed any output when using RBENV_DEBUG=1 and does not really
hurt to have in the unlikely case that it should fail; you would get
two error messages now:

rbenv: ruby: command not found
rbenv: system version not found in PATH