### PR TITLE
Improve init: warn about missing shell and use it in the template

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -71,10 +71,10 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and rbenv init - | source'
+      echo 'status --is-interactive; and rbenv init - fish | source'
       ;;
     * )
-      echo 'eval "$(rbenv init -)"'
+      printf 'eval "$(rbenv init - %s)"\n' "$shell"
       ;;
     esac
     echo

--- a/test/init.bats
+++ b/test/init.bats
@@ -51,10 +51,16 @@ OUT
   [ -z "$line" ] || flunk "did not expect line: $line"
 }
 
+@test "posix shell instructions" {
+  run rbenv-init bash
+  assert [ "$status" -eq 1 ]
+  assert_line 'eval "$(rbenv init - bash)"'
+}
+
 @test "fish instructions" {
   run rbenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'status --is-interactive; and rbenv init - | source'
+  assert_line 'status --is-interactive; and rbenv init - fish | source'
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
Providing the shell makes rbenv-init "only" take 50ms, instead of 90ms.

The slow part is coming from the `ps` that runs in a subshell when the
shell is not provided.

Therefore this will print a warning, and updates the template that
`rbenv init` itself generates.

I think in the long run `shell` should become a required argument, but
this is a good first step already.