### PR TITLE
Move the $RBENV-DIR functionality to an rbenv exec

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -29,6 +29,20 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
+if [ "\$program" = "ruby" ]; then
+  for arg; do
+    case "\$arg" in
+    -e* | -- ) break ;;
+    */* )
+      if [ -f "\$arg" ]; then
+        export RBENV_DIR="\${arg%/*}"
+        break
+      fi
+      ;;
+    esac
+  done
+fi
+
 export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -30,13 +30,13 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
-if [ "\$RBENV_COMMAND" = "ruby" ]; then
+if [ "$RBENV_COMMAND" = "ruby" ]; then
   for arg; do
-    case "\$arg" in
+    case "$arg" in
     -e* | -- ) break ;;
     */* )
-      if [ -f "\$arg" ]; then
-        export RBENV_DIR="\${arg%/*}"
+      if [ -f "$arg" ]; then
+        export RBENV_DIR="${arg%/*}"
         break
       fi
       ;;

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -23,6 +23,7 @@ fi
 
 RBENV_VERSION="$(rbenv-version-name)"
 RBENV_COMMAND="$1"
+shift 1
 
 if [ -z "$RBENV_COMMAND" ]; then
   rbenv-help --usage exec >&2
@@ -54,8 +55,8 @@ for script in "${scripts[@]}"; do
   source "$script"
 done
 
-shift 1
 if [ "$RBENV_VERSION" != "system" ]; then
   export PATH="${RBENV_BIN_PATH}:${PATH}"
 fi
+
 exec -a "$RBENV_COMMAND" "$RBENV_COMMAND_PATH" "$@"

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -29,7 +29,7 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
-if [ "\$program" = "ruby" ]; then
+if [ "\$RBENV_COMMAND" = "ruby" ]; then
   for arg; do
     case "\$arg" in
     -e* | -- ) break ;;

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -46,19 +46,6 @@ set -e
 [ -n "\$RBENV_DEBUG" ] && set -x
 
 program="\${0##*/}"
-if [ "\$program" = "ruby" ]; then
-  for arg; do
-    case "\$arg" in
-    -e* | -- ) break ;;
-    */* )
-      if [ -f "\$arg" ]; then
-        export RBENV_DIR="\${arg%/*}"
-        break
-      fi
-      ;;
-    esac
-  done
-fi
 
 export RBENV_ROOT="$RBENV_ROOT"
 exec "$(command -v rbenv)" exec "\$program" "\$@"


### PR DESCRIPTION
Replaces #1101. This patch tries to move shim functionaly from shims to rbenv exec since this should be universal, ie no diffence between rbenv exec $COMMAND and $COMMAND