### PR TITLE
test/run: handle optional paths/args for bats

### DIFF
--- a/test/run
+++ b/test/run
@@ -6,4 +6,4 @@ if [ -n "$RBENV_NATIVE_EXT" ]; then
   make -C src
 fi
 
-exec bats ${CI:+--tap} test
+exec bats ${CI:+--tap} "${@:-test}"


### PR DESCRIPTION
This allows to run a single test file more easily, although that could be
done by calling bats directly.