### PR TITLE
shims: handle exported SHELLOPTS

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -39,11 +39,14 @@ remove_prototype_shim() {
 # hard-linked for every executable and then removed. The linking
 # technique is fast, uses less disk space than unique files, and also
 # serves as a locking mechanism.
+# It protects itself against outer options (nounset, pipefail).
 create_prototype_shim() {
   cat > "$PROTOTYPE_SHIM_PATH" <<SH
 #!/usr/bin/env bash
 set -e
+set +o nounset
 [ -n "\$RBENV_DEBUG" ] && set -x
+set +o pipefail
 
 program="\${0##*/}"
 if [ "\$program" = "ruby" ]; then

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -107,3 +107,16 @@ SH
   run ruby -S rake
   assert_success "hello rake"
 }
+
+@test "shims handle SHELLOPTS" {
+  export RBENV_VERSION="2.0"
+
+  create_executable "myshim" <<SH
+#!/usr/bin/env bash
+echo hello from shim
+SH
+
+  rbenv-rehash
+  run env SHELLOPTS=nounset:pipefail myshim
+  assert_success "hello from shim"
+}


### PR DESCRIPTION
When SHELLOPTS is exported/set when bash starts up, it will use settings
from there.
A common use case might be to export/use it for "xtrace", but that
should not cause errors inside of rbenv/pyenv for things like `[ -n
"$FOO" ]`.

Ref: https://github.com/pyenv/pyenv/pull/1273
Ref: https://github.com/pyenv/pyenv/pull/1237