### PR TITLE
Support system-wide Ruby installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,25 @@ installed:
 Version names to rbenv are simply the names of the directories in
 `~/.rbenv/versions`.
 
+#### System-wide Ruby Installations
+
+Rbenv also supports system-wide Ruby installations. Such installations
+are available to all users on the system because they are not located
+in a home directory. This works through the `RBENV_SYSTEM_VERSIONS_DIR`
+environment variable: if it is set, then rbenv will look there
+*in addition to* looking in `~/.rbenv/versions`.
+
+For example, suppose that `RBENV_SYSTEM_VERSIONS_DIR` is set to
+`/usr/local/lib/rbenv/versions`. You might then have those versions
+installed:
+
+* `/usr/local/lib/rbenv/versions/2.4.0/`
+* `/usr/local/lib/rbenv/versions/2.6.2/`
+
+Note that `~/.rbenv/versions` has priority over `RBENV_SYSTEM_VERSIONS_DIR`.
+If a Ruby installation exists in both `~/.rbenv/versions` and
+`RBENV_SYSTEM_VERSIONS_DIR`, then rbenv will use the one in `~/.rbenv/versions`.
+
 ## Installation
 
 **Compatibility note**: rbenv is _incompatible_ with RVM. Please make
@@ -342,6 +361,30 @@ that directory can also be a symlink to a Ruby version installed
 elsewhere on the filesystem. rbenv doesn't care; it will simply treat
 any entry in the `versions/` directory as a separate Ruby version.
 
+#### Installing System-wide Ruby versions
+
+`rbenv install` always installs to `~/.rbenv/versions/`. If you want to
+install a Ruby version system-wide (i.e. you're going to use
+`RBENV_SYSTEM_VERSIONS_DIR`) then here's how to do it with ruby-build:
+
+~~~ sh
+# if ruby-build is installed as an rbenv plugin:
+$ sudo "$(rbenv root)/plugins/ruby-build" 2.6.2 "$RBENV_SYSTEM_VERSIONS_DIR/2.6.2"
+
+# if ruby-build is installed standalone:
+$ sudo ruby-build 2.6.2 "$RBENV_SYSTEM_VERSIONS_DIR/2.6.2"
+~~~
+
+The use of `sudo` in the above example is under the assumption that
+`RBENV_SYSTEM_VERSIONS_DIR` is only writable by root. You can omit sudo
+if the directory is writable by the current user. Note however that you
+should then carefully think about what appropriate permissions should be:
+it is generally a bad idea for a Ruby installation directory to be writable
+by multiple users.
+
+Again (as an alternative to using ruby-build), you can download and compile
+Ruby manually as a subdirectory of `RBENV_SYSTEM_VERSIONS_DIR`.
+
 #### Installing Ruby gems
 
 Once you've installed some Ruby versions, you'll want to install gems.
@@ -354,7 +397,8 @@ install gems as you normally would:
 $ gem install bundler
 ```
 
-**You don't need sudo** to install gems. Typically, the Ruby versions will be
+Unless the corresponding Ruby installation was installed system-wide,
+**you don't need sudo** to install gems. Typically, the Ruby versions will be
 installed and writeable by your user. No extra privileges are required to
 install gems.
 
@@ -368,7 +412,7 @@ $ gem env home
 ### Uninstalling Ruby versions
 
 As time goes on, Ruby versions you install will accumulate in your
-`~/.rbenv/versions` directory.
+`~/.rbenv/versions` directory (or in `RBENV_SYSTEM_VERSIONS_DIR`).
 
 To remove old Ruby versions, simply `rm -rf` the directory of the
 version you want to remove. You can find the directory of a particular
@@ -376,7 +420,8 @@ Ruby version with the `rbenv prefix` command, e.g. `rbenv prefix
 1.8.7-p357`.
 
 The [ruby-build][] plugin provides an `rbenv uninstall` command to
-automate the removal process.
+automate the removal process. That command however only supports
+removing from `~/.rbenv/versions`, not from `RBENV_SYSTEM_VERSIONS_DIR`.
 
 ### Uninstalling rbenv
 
@@ -401,6 +446,11 @@ uninstall from the system.
    perform the rbenv package removal. For instance, for Homebrew:
 
         brew uninstall rbenv
+
+ 3. If you installed any Ruby versions system-wide, then also be sure to
+    remove the entire `RBENV_SYSTEM_VERSIONS_DIR` directory:
+
+        sudo rm -rf "$RBENV_SYSTEM_VERSIONS_DIR"
 
 ## Command Reference
 
@@ -514,6 +564,7 @@ name | default | description
 `RBENV_DEBUG` | | Outputs debug information.<br>Also as: `rbenv --debug <subcommand>`
 `RBENV_HOOK_PATH` | [_see wiki_][hooks] | Colon-separated list of paths searched for rbenv hooks.
 `RBENV_DIR` | `$PWD` | Directory to start searching for `.ruby-version` files.
+`RBENV_SYSTEM_VERSIONS_DIR` | | Defines the directory under which system-wide Ruby versions reside.
 
 ## Development
 

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -10,7 +10,7 @@
 # For example, if the currently selected Ruby version is 1.9.3-p327:
 #   rbenv exec bundle install
 #
-# is equivalent to:
+# is similar to:
 #   PATH="$RBENV_ROOT/versions/1.9.3-p327/bin:$PATH" bundle install
 
 set -e

--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -33,10 +33,17 @@ if [ "$RBENV_VERSION" = "system" ]; then
   fi
 fi
 
-RBENV_PREFIX_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}"
-if [ ! -d "$RBENV_PREFIX_PATH" ]; then
-  echo "rbenv: version \`${RBENV_VERSION}' not installed" >&2
-  exit 1
+RBENV_PREFIX_PATHS=("${RBENV_ROOT}/versions/${RBENV_VERSION}")
+if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+  RBENV_PREFIX_PATHS+=("${RBENV_SYSTEM_VERSIONS_DIR}/${RBENV_VERSION}")
 fi
 
-echo "$RBENV_PREFIX_PATH"
+for RBENV_PREFIX_PATH in "${RBENV_PREFIX_PATHS[@]}"; do
+  if [ -d "$RBENV_PREFIX_PATH" ]; then
+    echo "$RBENV_PREFIX_PATH"
+    exit 0
+  fi
+done
+
+echo "rbenv: version \`${RBENV_VERSION}' not installed" >&2
+exit 1

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -82,10 +82,17 @@ remove_outdated_shims() {
 # List basenames of executables for every Ruby version
 list_executable_names() {
   local version file
+  local -a version_dirs
   rbenv-versions --bare --skip-aliases | \
   while read -r version; do
-    for file in "${RBENV_ROOT}/versions/${version}/bin/"*; do
-      echo "${file##*/}"
+    version_dirs=("${RBENV_ROOT}/versions/${version}")
+    if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+      version_dirs+=("$RBENV_SYSTEM_VERSIONS_DIR/${version}")
+    fi
+    for version_dir in "${version_dirs[@]}"; do
+      for file in "${version_dir}/bin/"*; do
+        echo "${file##*/}"
+      done
     done
   done
 }

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -22,7 +22,16 @@ fi
 
 version_exists() {
   local version="$1"
-  [ -d "${RBENV_ROOT}/versions/${version}" ]
+  local -a version_dirs=("${RBENV_ROOT}/versions/${version}")
+  if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+    version_dirs+=("$RBENV_SYSTEM_VERSIONS_DIR/${version}")
+  fi
+  for version_dir in "${version_dirs[@]}"; do
+    if [ -d "${version_dir}" ]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 if version_exists "$RBENV_VERSION"; then

--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -25,7 +25,10 @@ for arg; do
   esac
 done
 
-versions_dir="${RBENV_ROOT}/versions"
+versions_dirs=("${RBENV_ROOT}/versions")
+if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+  versions_dirs+=("$RBENV_SYSTEM_VERSIONS_DIR")
+fi
 
 if ! enable -f "${BASH_SOURCE%/*}"/rbenv-realpath.dylib realpath 2>/dev/null; then
   if [ -n "$RBENV_NATIVE_EXT" ]; then
@@ -59,9 +62,12 @@ if ! enable -f "${BASH_SOURCE%/*}"/rbenv-realpath.dylib realpath 2>/dev/null; th
   }
 fi
 
-if [ -d "$versions_dir" ]; then
-  versions_dir="$(realpath "$versions_dir")"
-fi
+for i in "${!versions_dirs[@]}"; do
+  versions_dir="${versions_dirs[$i]}"
+  if [ -d "$versions_dir" ]; then
+    versions_dirs[$i]="$(realpath "$versions_dir")"
+  fi
+done
 
 if [ -n "$bare" ]; then
   hit_prefix=""
@@ -92,14 +98,16 @@ if [ -n "$include_system" ] && RBENV_VERSION=system rbenv-which ruby >/dev/null 
 fi
 
 shopt -s nullglob
-for path in "$versions_dir"/*; do
-  if [ -d "$path" ]; then
-    if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
-      target="$(realpath "$path")"
-      [ "${target%/*}" != "$versions_dir" ] || continue
+for versions_dir in "${versions_dirs[@]}"; do
+  for path in "$versions_dir"/*; do
+    if [ -d "$path" ]; then
+      if [ -n "$skip_aliases" ] && [ -L "$path" ]; then
+        target="$(realpath "$path")"
+        [ "${target%/*}" != "$versions_dir" ] || continue
+      fi
+      print_version "${path##*/}"
     fi
-    print_version "${path##*/}"
-  fi
+  done
 done
 shopt -u nullglob
 

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -38,9 +38,12 @@ RBENV_VERSION="${RBENV_VERSION:-$(rbenv-version-name)}"
 
 if [ "$RBENV_VERSION" = "system" ]; then
   PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \
-    RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
+    RBENV_COMMAND_PATHS=("$(command -v "$RBENV_COMMAND" || true)")
 else
-  RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
+  RBENV_COMMAND_PATHS=("${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}")
+  if [ -n "$RBENV_SYSTEM_VERSIONS_DIR" ]; then
+    RBENV_COMMAND_PATHS+=("${RBENV_SYSTEM_VERSIONS_DIR}/${RBENV_VERSION}/bin/${RBENV_COMMAND}")
+  fi
 fi
 
 OLDIFS="$IFS"
@@ -50,9 +53,14 @@ for script in "${scripts[@]}"; do
   source "$script"
 done
 
-if [ -x "$RBENV_COMMAND_PATH" ]; then
-  echo "$RBENV_COMMAND_PATH"
-elif [ "$RBENV_VERSION" != "system" ] && [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
+for RBENV_COMMAND_PATH in "${RBENV_COMMAND_PATHS[@]}"; do
+  if [ -x "$RBENV_COMMAND_PATH" ]; then
+    echo "$RBENV_COMMAND_PATH"
+    exit 0
+  fi
+done
+
+if [ "$RBENV_VERSION" != "system" ] && [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
   echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $(rbenv-version-origin))" >&2
   exit 1
 else

--- a/test/prefix.bats
+++ b/test/prefix.bats
@@ -43,3 +43,13 @@ rbenv: ruby: command not found
 rbenv: system version not found in PATH"
 EOF
 }
+
+@test "prefix for system-wide ruby version" {
+  setup_system_versions_dir
+  mkdir -p "${RBENV_TEST_DIR}/myproject"
+  cd "${RBENV_TEST_DIR}/myproject"
+  echo "1.2.3" > .ruby-version
+  mkdir -p "${RBENV_SYSTEM_VERSIONS_DIR}/1.2.3"
+  run rbenv-prefix
+  assert_success "${RBENV_SYSTEM_VERSIONS_DIR}/1.2.3"
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -26,6 +26,8 @@ if [ -z "$RBENV_TEST_DIR" ]; then
   PATH="${RBENV_ROOT}/shims:$PATH"
   export PATH
 
+  unset RBENV_SYSTEM_VERSIONS_DIR
+
   for xdg_var in `env 2>/dev/null | grep ^XDG_ | cut -d= -f1`; do unset "$xdg_var"; done
   unset xdg_var
 fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -36,6 +36,11 @@ teardown() {
   rm -rf "$RBENV_TEST_DIR"
 }
 
+setup_system_versions_dir() {
+  export RBENV_SYSTEM_VERSIONS_DIR="$RBENV_TEST_DIR/system-versions"
+  mkdir -p "$RBENV_SYSTEM_VERSIONS_DIR"
+}
+
 flunk() {
   { if [ "$#" -eq 0 ]; then cat -
     else echo "$@"

--- a/test/versions.bats
+++ b/test/versions.bats
@@ -6,6 +6,10 @@ create_version() {
   mkdir -p "${RBENV_ROOT}/versions/$1"
 }
 
+create_system_version() {
+  mkdir -p "${RBENV_SYSTEM_VERSIONS_DIR}/$1"
+}
+
 setup() {
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
@@ -152,5 +156,15 @@ OUT
   assert_output <<OUT
 1.8.7
 1.9
+OUT
+}
+
+@test "finds versions in the system versions dir" {
+  setup_system_versions_dir
+  create_system_version "2.6.2"
+  run rbenv-versions --bare
+  assert_success
+  assert_output <<OUT
+2.6.2
 OUT
 }

--- a/test/which.bats
+++ b/test/which.bats
@@ -12,6 +12,16 @@ create_executable() {
   chmod +x "${bin}/$2"
 }
 
+create_system_wide_executable() {
+  local bin
+  if [[ $1 == */* ]]; then bin="$1"
+  else bin="${RBENV_SYSTEM_VERSIONS_DIR}/${1}/bin"
+  fi
+  mkdir -p "$bin"
+  touch "${bin}/$2"
+  chmod +x "${bin}/$2"
+}
+
 @test "outputs path to executable" {
   create_executable "1.8" "ruby"
   create_executable "2.0" "rspec"
@@ -83,9 +93,11 @@ create_executable() {
 }
 
 @test "executable found in other versions" {
+  setup_system_versions_dir
   create_executable "1.8" "ruby"
   create_executable "1.9" "rspec"
   create_executable "2.0" "rspec"
+  create_system_wide_executable "2.1" "rspec"
 
   RBENV_VERSION=1.8 run rbenv-which rspec
   assert_failure
@@ -95,6 +107,7 @@ rbenv: rspec: command not found
 The \`rspec' command exists in these Ruby versions:
   1.9
   2.0
+  2.1
 OUT
 }
 


### PR DESCRIPTION
Makes rbenv look for Ruby installations in both ~/.rbenv/versions _as well as_ in `RBENV_SYSTEM_VERSIONS_DIR`, if set. This allows installing Ruby versions in a system-wide manner that's available to all users on the system.