### PR TITLE
Disallow path segments and directory traversal in `.ruby-version` files

### DIFF
--- a/libexec/rbenv-version-file-read
+++ b/libexec/rbenv-version-file-read
@@ -11,7 +11,9 @@ if [ -e "$VERSION_FILE" ]; then
   words=( $(cut -b 1-1024 "$VERSION_FILE") )
   version="${words[0]}"
 
-  if [ -n "$version" ]; then
+  if [ "$version" = ".." ] || [[ $version == */* ]]; then
+    echo "rbenv: invalid version in \`$VERSION_FILE'" >&2
+  elif [ -n "$version" ]; then
     echo "$version"
     exit
   fi

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -70,3 +70,19 @@ IN
   run rbenv-version-file-read my-version
   assert_success "1.9.3"
 }
+
+@test "prevents directory traversal" {
+  cat > my-version <<<".."
+  run rbenv-version-file-read my-version
+  assert_failure "rbenv: invalid version in \`my-version'"
+
+  cat > my-version <<<"../foo"
+  run rbenv-version-file-read my-version
+  assert_failure "rbenv: invalid version in \`my-version'"
+}
+
+@test "disallows path segments in version string" {
+  cat > my-version <<<"foo/bar"
+  run rbenv-version-file-read my-version
+  assert_failure "rbenv: invalid version in \`my-version'"
+}


### PR DESCRIPTION
A malicious `.ruby-version` file in the current directory could inject `../../../` into the version string and trigger execution of binaries outside of `RBENV_ROOT/versions/`.

Fixes #977 OVE-20170303-0004