### PR TITLE
Added `upgrade` command

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -151,7 +151,7 @@ if [ -z "$1" ] || [ "$1" == "rbenv" ]; then
   [ -z "$usage" ] || exit
   echo
   echo "Some useful rbenv commands are:"
-  print_summaries commands local global shell install uninstall rehash version versions which whence
+  print_summaries commands local global shell install uninstall rehash version versions which whence upgrade
   echo
   echo "See \`rbenv help <command>' for information on a specific command."
   echo "For full documentation, see: https://github.com/rbenv/rbenv#readme"

--- a/libexec/rbenv-upgrade
+++ b/libexec/rbenv-upgrade
@@ -22,19 +22,19 @@ is_app_installed() {
 base_path=$(dirname $0)
 
 if is_git_repository "${base_path}"; then
- cd "${base_path}"
+  cd "${base_path}"
  
- echo "Upgrading rbenv..."
- git pull
-
- ruby_build_path="../plugins/ruby-build"
-
- if [ -d "${ruby_build_path}" ]; then
-  cd "${ruby_build_path}"
-
-  echo "Upgrading Ruby-build..."
+  echo "Upgrading rbenv..."
   git pull
-fi
+
+  ruby_build_path="../plugins/ruby-build"
+
+  if [ -d "${ruby_build_path}" ]; then
+    cd "${ruby_build_path}"
+
+    echo "Upgrading Ruby-build..."
+    git pull
+  fi
 elif is_app_installed 'brew'; then
   echo "Upgrading rbenv..."
   brew upgrade rbenv ruby-build

--- a/libexec/rbenv-upgrade
+++ b/libexec/rbenv-upgrade
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Summary: Upgrade rbenv (and ruby-build, if installed) to the latest version
+#
+# Upgrades rbenv and ruby-build to the latest version.
+
+set -e
+[ -n "$RBENV_DEBUG" ] && set -x
+
+is_git_repository() {
+  local path
+  path="$1"
+  [[ -n $(cd "$path" && git rev-parse --git-dir 2> /dev/null) ]]
+}
+
+is_app_installed() {
+  local app_name;
+  app_name="$1"
+
+  which "$1" > /dev/null 2>&1
+}
+
+base_path=$(dirname $0)
+
+if is_git_repository "${base_path}"; then
+ cd "${base_path}"
+ 
+ echo "Upgrading rbenv..."
+ git pull
+
+ ruby_build_path="../plugins/ruby-build"
+
+ if [ -d "${ruby_build_path}" ]; then
+  cd "${ruby_build_path}"
+
+  echo "Upgrading Ruby-build..."
+  git pull
+fi
+elif is_app_installed 'brew'; then
+  echo "Upgrading rbenv..."
+  brew upgrade rbenv ruby-build
+fi


### PR DESCRIPTION
Hi there,

I was a little surprised that there wasn't a way to upgrade rbenv using the rbenv command line, so I've added an `upgrade` command which will upgrade both `git` and `brew`-installed versions of `rbenv` and `ruby-build` (if installed).

This PR adds `rbenv upgrade` and adds the `upgrade` command to the useful commands list in `help`:
```
$ rbenv 
rbenv 1.1.2-3-g6a38b2c
Usage: rbenv <command> [<args>]

Some useful rbenv commands are:
   commands    List all available rbenv commands
   local       Set or show the local application-specific Ruby version
   global      Set or show the global Ruby version
   shell       Set or show the shell-specific Ruby version
   install     Install a Ruby version using ruby-build
   uninstall   Uninstall a specific Ruby version
   rehash      Rehash rbenv shims (run this after installing executables)
   version     Show the current Ruby version and its origin
   versions    List installed Ruby versions
   which       Display the full path to an executable
   whence      List all Ruby versions that contain the given executable
   upgrade     Upgrade rbenv (and ruby-build, if installed) to the latest version

See `rbenv help <command>' for information on a specific command.
For full documentation, see: https://github.com/rbenv/rbenv#readme
```

**Note:** This has not been tested with homebrew, as I don't have access to MacOS at the moment. It works on Linux, though!

Thanks!