### PR TITLE
Handle "ruby-" prefix consistently

### DIFF
--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -17,8 +17,16 @@ fi
 
 if [ -n "$1" ]; then
   export RBENV_VERSION="$1"
-elif [ -z "$RBENV_VERSION" ]; then
+fi
+
+if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-name)"
+elif [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
+  RBENV_VERSION="${RBENV_VERSION#ruby-}"
+  if [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
+    echo "rbenv: version \`$RBENV_VERSION' is not installed" >&2
+    exit 1
+  fi
 fi
 
 if [ "$RBENV_VERSION" = "system" ]; then

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -34,7 +34,15 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
-RBENV_VERSION="${RBENV_VERSION:-$(rbenv-version-name)}"
+if [ -z "$RBENV_VERSION" ]; then
+  RBENV_VERSION="$(rbenv-version-name)"
+elif [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
+  RBENV_VERSION="${RBENV_VERSION#ruby-}"
+  if [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
+    echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $(rbenv-version-origin))" >&2
+    exit 1
+  fi
+fi
 
 if [ "$RBENV_VERSION" = "system" ]; then
   PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \


### PR DESCRIPTION
Most rbenv commands handle ruby-2.6.3 the same way as 2.6.3.

```bash
$ export RBENV_VERSION=ruby-2.6.3

$ rbenv version-name
2.6.3

$ rbenv versions
* 2.6.3 (set by RBENV_VERSION environment variable)

$ rbenv whence ruby
2.6.3

$ ruby -v
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-linux]
```

The two exceptions are `rbenv which` and `rbenv prefix`. This PR makes these two commands consistent with the rest.

Before:

```bash
$ rbenv prefix
rbenv: version `ruby-2.6.3' not installed

$ rbenv which ruby
rbenv: version `ruby-2.6.3' is not installed (set by RBENV_VERSION environment variable)
```

After:

```bash
$ rbenv which ruby
/home/romka/.rbenv/versions/2.6.3/bin/ruby

$ rbenv prefix
/home/romka/.rbenv/versions/2.6.3
```

Not: `rbenv which` used to handle "ruby-" prefix until 6bb7f07d. The change in behavior doesn't seem intentional from the PR and commit description.