### PR TITLE
Add a closing double quote to rbenv-init for non fish shell on MacOS …

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -149,6 +149,6 @@ cat <<EOS
   *)
     command rbenv "\$command" "\$@";;
   esac
-}
+}"
 EOS
 fi


### PR DESCRIPTION
#1176 
Add a closing double quote at the end of the rbenv-init file.