### PR TITLE
Add message to rbenv-global when use .ruby-version

### DIFF
--- a/libexec/rbenv-global
+++ b/libexec/rbenv-global
@@ -29,3 +29,7 @@ if [ -n "$RBENV_VERSION" ]; then
 else
   rbenv-version-file-read "$RBENV_VERSION_FILE" || echo system
 fi
+
+if [ -e .ruby-version ]; then
+  echo local configuration file '.ruby-version' is used
+fi


### PR DESCRIPTION
for https://github.com/rbenv/rbenv/issues/1185

I used Ruby 2.5.0 and trying to switch to 2.6.2.
But version did not change even if I use `rbenv glabal`.

Apparently `$HOME/.rbenv/version` was not reflected because There is `$HOME/.ruby-version` the directory I was in.

It took time to identify the cause.So how about outputting a message when `version` file is under the home directory?
