### PR TITLE
Show how to update the list of available Ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ RVM?**](https://github.com/rbenv/rbenv/wiki/Why-rbenv%3F)
     * [Upgrading with Homebrew](#upgrading-with-homebrew)
   * [Basic GitHub Checkout](#basic-github-checkout)
     * [Upgrading with Git](#upgrading-with-git)
+    * [Updating the list of available Ruby versions](#updating-the-list-of-available-ruby-versions)
   * [How rbenv hooks into your shell](#how-rbenv-hooks-into-your-shell)
   * [Installing Ruby versions](#installing-ruby-versions)
     * [Installing Ruby gems](#installing-ruby-gems)
@@ -288,6 +289,15 @@ latest version by pulling from GitHub:
 $ cd ~/.rbenv
 $ git pull
 ~~~
+
+#### Updating the list of available Ruby versions
+
+If you're using the `rbenv install` command, then the list of available Ruby versions is not automatically updated when pulling from the rbenv repo. To do this manually:
+
+```sh
+$ cd ~/.rbenv/plugins/ruby-build
+$ git pull
+```
 
 ### How rbenv hooks into your shell
 


### PR DESCRIPTION
It wasn't clear how to update the list of installable Ruby versions after installing rbenv from Git. This is a bit confusing for people who use rbenv to run third party Ruby apps rather than write their own and are less likely to know/care about the distinction between `rbenv` and `ruby-build`. I hadn't touched it for about 2 years and totally forgot that I'd need to manually update ruby-build.

Alternatively, it might be better to make ruby-build a git submodule.