### PR TITLE
Add attention message about anti virus software

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ If you're on macOS, we recommend installing rbenv with
 5. That's it! Installing rbenv includes ruby-build, so now you're ready to
    [install some other Ruby versions](#installing-ruby-versions) using
    `rbenv install`.
+   
+   Attention: If you have installed anti-virus-software on your pc, 
+   you should stop it before your `rbenv install`. 
+   If you use this without stopping, you cannot install ruby ver.xxx.
 
 
 #### Upgrading with Homebrew


### PR DESCRIPTION
This modification is related to issue [#1334](https://github.com/rbenv/ruby-build/issues/1334) .
If we have installed anti-virus-software on our pc, we should stop it before our `rbenv install`. 
If we use this without stopping, we cannot install ruby ver.xxx. Hence, I added this modification.