### PR TITLE
Add --depth=1 parameter for cloning rbenv using Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ a systemwide install.
 1. Clone rbenv into `~/.rbenv`.
 
     ~~~ sh
-    $ git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+    $ git clone --depth=1 https://github.com/rbenv/rbenv.git ~/.rbenv
     ~~~
 
     Optionally, try to compile dynamic bash extension to speed up rbenv. Don't


### PR DESCRIPTION
People don't need to clone the whole Git history of **rbenv** when they want to use it. This is can be done by adding `--depth=1` parameter at Git clone command. By not cloning the whole Git history, clone time and space occupied will be reduced.

### Benchmarking

#### Clone all history

```
$ time git clone https://github.com/rbenv/rbenv.git ~/.rbenv-depth-all                
Cloning into '/home/nieltg/.rbenv-depth-all'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 2763 (delta 0), reused 2 (delta 0), pack-reused 2759
Receiving objects: 100% (2763/2763), 534.99 KiB | 515.00 KiB/s, done.
Resolving deltas: 100% (1731/1731), done.
git clone https://github.com/rbenv/rbenv.git ~/.rbenv-depth-all  0.16s user 0.07s system 7% cpu 3.274 total
$ du -s ~/.rbenv-depth-all                                            
1016    /home/nieltg/.rbenv-depth-all
```

**Clone time:** 3.27 s
**Disc usage:** 1016

#### Clone using `--depth=1`
```
$ time git clone --depth=1 https://github.com/rbenv/rbenv.git ~/.rbenv-depth-1
Cloning into '/home/nieltg/.rbenv-depth-1'...
remote: Enumerating objects: 80, done.
remote: Counting objects: 100% (80/80), done.
remote: Compressing objects: 100% (72/72), done.
remote: Total 80 (delta 1), reused 29 (delta 0), pack-reused 0
Unpacking objects: 100% (80/80), done.
git clone --depth=1 https://github.com/rbenv/rbenv.git ~/.rbenv-depth-1  0.07s user 0.07s system 4% cpu 3.133 total
$ du -s ~/.rbenv-depth-1                                                      
732     /home/nieltg/.rbenv-depth-1
```

**Clone time:** 3.13 s
**Disc usage:** 732

#### Summary

**Clone time improvement:** 4.31% faster.
**Disc usage shrinkage:** 27.95% smaller.

And these number will be increasing as this repository grows.