### PR TITLE
rbenv help: fix 'type: write error: Broken pipe'

### DIFF
--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -42,8 +42,13 @@ extract_initial_comment_block() {
 }
 
 collect_documentation() {
+  local all_awks
+  local first_awk
+  all_awks=$(type -p gawk awk)
+  first_awk=$(head -1 <<<"$all_awks")
+
   # shellcheck disable=SC2016
-  $(type -p gawk awk | head -1) '
+  "$first_awk" '
     /^Summary:/ {
       summary = substr($0, 10)
       next


### PR DESCRIPTION
Sometimes the command fails with a 'type: write error: Broken pipe'. This is because 'head -1' only reads the first line, then exits. If 'type' writes the second line after 'head -1' has already exited, then the aforementioned error is triggered.

We fix this by buffering the entire output of 'type' before invoking 'head -1'.