### PR TITLE
Fix fish shell initialization

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -114,7 +114,7 @@ function rbenv
 
   switch "\$command"
   case ${commands[*]}
-    source (rbenv "sh-\$command" \$argv|psub)
+    rbenv "sh-\$command" \$argv|source
   case '*'
     command rbenv "\$command" \$argv
   end

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -70,7 +70,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and source (rbenv init -|psub)'
+      echo 'status --is-interactive; and rbenv init - | source'
       ;;
     * )
       echo 'eval "$(rbenv init -)"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -54,7 +54,7 @@ OUT
 @test "fish instructions" {
   run rbenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'status --is-interactive; and source (rbenv init -|psub)'
+  assert_line 'status --is-interactive; and rbenv init - | source'
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
Since fish 3.10 at least, the current way of loading rbenv in `fish` is misbehaving, at least in some environments:

```
source: Error encountered while sourcing file '/var/folders/pj/jn249gcn7ddfrjzj2_9mxjhw0000gp/T//.psub.f0iJSWRByB':
source: No such file or directory
```

This changes the initialization to the method recommended by a `fish` developer here: https://github.com/fish-shell/fish-shell/issues/6613#issuecomment-586679958