### PR TITLE
Remove .agignore

### DIFF
--- a/.agignore
+++ b/.agignore
@@ -1,2 +1,0 @@
-./versions
-./cache


### PR DESCRIPTION
Silver Searcher respects .gitignore, so having an .agignore file is
redundant. (Both patterns present in .agignore are already present in
.gitignore.)

It's also worth noting that silver searcher uses .agignore _in addition
to_ .gitignore, so removing this file will not cause ag to start
ignoring _additional_ patterns from .gitignore (it's already respecting
those patterns).


Personally, I think we should also remove .vimrc (in favor of vim plugins that map gitignore to wildignore). Thoughts?