### PR TITLE
Add `--force to Rehash Command

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -10,20 +10,26 @@ PROTOTYPE_SHIM_PATH="${SHIM_PATH}/.rbenv-shim"
 # Create the shims directory if it doesn't already exist.
 mkdir -p "$SHIM_PATH"
 
+if [ "$1" = "-f" ] || [ "$1" = "--force" ]; then
+  FORCE="true"
+fi
+
 # Ensure only one instance of rbenv-rehash is running at a time by
 # setting the shell's `noclobber` option and attempting to write to
 # the prototype shim file. If the file already exists, print a warning
 # to stderr and exit with a non-zero status.
 set -o noclobber
-{ echo > "$PROTOTYPE_SHIM_PATH"
-} 2>| /dev/null ||
-{ if [ -w "$SHIM_PATH" ]; then
-    echo "rbenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
-  else
-    echo "rbenv: cannot rehash: $SHIM_PATH isn't writable"
-  fi
-  exit 1
-} >&2
+if [ -z "$FORCE" ]; then
+  { echo > "$PROTOTYPE_SHIM_PATH"
+  } 2>| /dev/null ||
+  { if [ -w "$SHIM_PATH" ]; then
+      echo "rbenv: cannot rehash: $PROTOTYPE_SHIM_PATH exists"
+    else
+      echo "rbenv: cannot rehash: $SHIM_PATH isn't writable"
+    fi
+    exit 1
+  } >&2
+fi
 set +o noclobber
 
 # If we were able to obtain a lock, register a trap to clean up the

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -31,6 +31,15 @@ create_executable() {
   assert_failure "rbenv: cannot rehash: ${RBENV_ROOT}/shims/.rbenv-shim exists"
 }
 
+@test "force even though rehash in progress" {
+  mkdir -p "${RBENV_ROOT}/shims"
+  touch "${RBENV_ROOT}/shims/.rbenv-shim"
+  run rbenv-rehash -f
+  assert_success ""
+  run rbenv-rehash --force
+  assert_success ""
+}
+
 @test "creates shims" {
   create_executable "1.8" "ruby"
   create_executable "1.8" "rake"


### PR DESCRIPTION
The `rbenv rehash` subcommand can leave the `.rbenv-shim` file around
even though the rehash is clearly complete. Additionally, previous
failed rehashes will cause this file to be left around. To prevent
having to `rm` the file prior to running the rehash command, users who
are confident that rehashing right now won't break anything can append a
`--force` or `-f` flag to ignore and remove this file automatically
before rehashing.