### PR TITLE
bash completion: avoid unintentional globbing

### DIFF
--- a/completions/rbenv.bash
+++ b/completions/rbenv.bash
@@ -6,8 +6,8 @@ _rbenv() {
     COMPREPLY=( $(compgen -W "$(rbenv commands)" -- "$word") )
   else
     local words=("${COMP_WORDS[@]}")
-    unset words[0]
-    unset words[$COMP_CWORD]
+    unset "words[0]"
+    unset "words[$COMP_CWORD]"
     local completions=$(rbenv completions "${words[@]}")
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
   fi


### PR DESCRIPTION
For example, unquoted `unset words[0]` fails to do the right thing if there's a file `words0` in the current dir.