### PR TITLE
Prevent duplicated shims in PATH variable

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -84,13 +84,16 @@ fi
 
 mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
+no_path=1
+[[ ":${PATH}:" != *":${RBENV_ROOT}/shims:"* ]] && no_path=""
+
 case "$shell" in
 fish )
-  echo "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
+  [[ -z "$no_path" ]] && echo "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
   echo "set -gx RBENV_SHELL $shell"
 ;;
 * )
-  echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  [[ -z "$no_path" ]] && echo 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
   echo "export RBENV_SHELL=$shell"
 
   completion="${root}/completions/rbenv.${shell}"

--- a/test/init.bats
+++ b/test/init.bats
@@ -77,18 +77,18 @@ OUT
   assert_line 0 "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
-@test "can add shims to PATH more than once" {
+@test "does not add shims to PATH more than once" {
   export PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - bash
   assert_success
-  assert_line 0 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
+  refute_line 'export PATH="'${RBENV_ROOT}'/shims:${PATH}"'
 }
 
-@test "can add shims to PATH more than once (fish)" {
+@test "does not add to PATH more than once (fish)" {
   export PATH="${RBENV_ROOT}/shims:$PATH"
   run rbenv-init - fish
   assert_success
-  assert_line 0 "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
+  refute_line "set -gx PATH '${RBENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {


### PR DESCRIPTION
This happens when someone adds the shims folder to the PATH variable manually.

References https://github.com/pyenv/pyenv/pull/1769.