### PR TITLE
test(init): remove misleading arg in detect from parent shell case

### DIFF
--- a/test/init.bats
+++ b/test/init.bats
@@ -39,7 +39,7 @@ eval "\$(rbenv-init -)"
 echo \$RBENV_SHELL
 OUT
   chmod +x myscript.sh
-  run ./myscript.sh /bin/zsh
+  run ./myscript.sh
   assert_success "sh"
 }
 


### PR DESCRIPTION
The generated script does not take/use any arguments, so passing
/bin/zsh to it serves only to cause confusion.