### PR TITLE
Supply `head -n` flag explicitly

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -29,7 +29,7 @@ if enable -f "${BASH_SOURCE%/*}"/../libexec/rbenv-realpath.dylib realpath 2>/dev
 else
   [ -z "$RBENV_NATIVE_EXT" ] || abort "failed to load \`realpath' builtin"
 
-  READLINK=$(type -p greadlink readlink 2>/dev/null | head -1)
+  READLINK=$(type -p greadlink readlink 2>/dev/null | head -n1)
   [ -n "$READLINK" ] || abort "cannot find readlink - are you missing GNU coreutils?"
 
   resolve_link() {

--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -43,7 +43,7 @@ extract_initial_comment_block() {
 
 collect_documentation() {
   local awk
-  awk="$(type -p gawk awk 2>/dev/null | head -1)"
+  awk="$(type -p gawk awk 2>/dev/null | head -n1)"
   if [ -z "$awk" ]; then
     echo "rbenv: cannot find awk" >&2
     return 1

--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -26,7 +26,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/rbenv-realpath.dylib realpath 2>/dev/null; th
     echo "rbenv: failed to load \`realpath' builtin" >&2
     exit 1
   fi
-READLINK=$(type -p greadlink readlink 2>/dev/null | head -1)
+READLINK=$(type -p greadlink readlink 2>/dev/null | head -n1)
 if [ -z "$READLINK" ]; then
   echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
   exit 1

--- a/libexec/rbenv-versions
+++ b/libexec/rbenv-versions
@@ -33,7 +33,7 @@ if ! enable -f "${BASH_SOURCE%/*}"/rbenv-realpath.dylib realpath 2>/dev/null; th
     exit 1
   fi
 
-  READLINK=$(type -p greadlink readlink 2>/dev/null | head -1)
+  READLINK=$(type -p greadlink readlink 2>/dev/null | head -n1)
   if [ -z "$READLINK" ]; then
     echo "rbenv: cannot find readlink - are you missing GNU coreutils?" >&2
     exit 1

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -87,7 +87,7 @@ OUT
 if [[ \$1 == "-S"* ]]; then
   found="\$(PATH="\${RUBYPATH:-\$PATH}" which \$2)"
   # assert that the found executable has ruby for shebang
-  if head -1 "\$found" | grep ruby >/dev/null; then
+  if head -n1 "\$found" | grep ruby >/dev/null; then
     \$BASH "\$found"
   else
     echo "ruby: no Ruby script found in input (LoadError)" >&2


### PR DESCRIPTION
The syntax `head -NUM` was deprecated in the POSIX standard.
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/head.html

Fixes #1314
