### PR TITLE
Update code block in readme for rbenv-doctor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ uninstall from the system.
   remove rbenv shims directory from PATH, and future invocations like
   `ruby` will execute the system Ruby version, as before rbenv.
 
-  `rbenv` will still be accessible on the command line, but your Ruby
+   While disabled, `rbenv` will still be accessible on the command line, but your Ruby
   apps won't be affected by version switching.
 
 2. To completely **uninstall** rbenv, perform step (1) and then remove
@@ -400,18 +400,11 @@ uninstall from the system.
         rm -rf `rbenv root`
 
    If you've installed rbenv using a package manager, as a final step
-   perform the rbenv package removal.
-   - Homebrew:
-   
-        `brew uninstall rbenv`
+   perform the rbenv package removal:
+   - Homebrew: `brew uninstall rbenv`
+   - Debian, Ubuntu, and their derivatives: `sudo apt purge rbenv`
+   - Archlinux and its derivatives: `sudo pacman -R rbenv`
 
-   - Debian, Ubuntu and their derivatives:
-        
-        `sudo apt purge rbenv`
-  
-   - Archlinux and it's derivatives:
-  
-        `sudo pacman -R rbenv`
 
 ## Command Reference
 


### PR DESCRIPTION
## Summary
Updates the code-block for the rbenv-doctor script in the readme to provide clearer instructions and convenient copy/paste functionally. 

## Description
This change updates the readme to add clarity for users attempting to run the rbenv-doctor script in the Installation instructions. Currently, the script and expected output are combined in a single code-block.

GitHub provides functionality to copy code from a code-block. Thus, when a user clicks the copy-icon in the code block to quickly copy the script, the user copies both the script and expected output. Since the output message contains inconsistencies with its quotes (using both traditional quotes and back-ticks), the copied text has an open back-tick. Ultimately, the script will not successfully run. 

This quick change separates the rbenv-doctor script from the expected output into distinct code-blocks. This results in greater clarity between the instructions and example output. In addition, it allows users to quickly and conveniently copy the script for use.

## Before

![image](https://user-images.githubusercontent.com/68248886/137566825-706684e6-79fa-4ca0-8a94-e94714e1447d.png)

## After

![Screen Shot 2021-10-15 at 5 47 14 PM](https://user-images.githubusercontent.com/68248886/137567155-3d52796e-e443-4a49-a0f4-2a52d8fa5fb7.png)


