### PR TITLE
Use test -aP instead of which -a in test helper

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -114,7 +114,7 @@ path_without() {
   local exe="$1"
   local path=":${PATH}:"
   local found alt util
-  for found in $(which -a "$exe"); do
+  for found in $(type -aP "$exe"); do
     found="${found%/*}"
     if [ "$found" != "${RBENV_ROOT}/shims" ]; then
       alt="${RBENV_TEST_DIR}/$(echo "${found#/}" | tr '/' '-')"


### PR DESCRIPTION
The former is a bash builtin, latter not necessarily available. For
example, `which` is deprecated in Debian's debianutils >= 5.0.

