### PR TITLE
Fix bug with bash completion and enabled failglob shell option

### DIFF
--- a/completions/rbenv.bash
+++ b/completions/rbenv.bash
@@ -5,10 +5,7 @@ _rbenv() {
   if [ "$COMP_CWORD" -eq 1 ]; then
     COMPREPLY=( $(compgen -W "$(rbenv commands)" -- "$word") )
   else
-    local words=("${COMP_WORDS[@]}")
-    unset "words[0]"
-    unset "words[$COMP_CWORD]"
-    local completions=$(rbenv completions "${words[@]}")
+    local completions=$(rbenv completions "${COMP_WORDS[@]: -2:1}")
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
   fi
 }


### PR DESCRIPTION
I'm using pyenv, which is based on rbenv. The described problem should affect pyenv as well as rbenv, so instead of issuing a pull request for pyenv I'm doing it for rbenv. pyenv states that fixes in rbenv will eventually be applied to pyenv as well. So I hope this is the right thing to do.

Recently, I started using bash with the `failglob` option enabled (`shopt -s failglob`).
With that shell option enabled, I noticed that the completion for pyenv failed with `bash: no match: words[0]`.

The problem seems to be fixed with rewriting the code that removes the first and last array items for completion. This seems also to be more along the line of what is done in rbenv.zsh.

