### PR TITLE
Tab completion- ensure a zsh user's prior shell options don't interfere with indexing into an array of arguments

### DIFF
--- a/completions/rbenv.zsh
+++ b/completions/rbenv.zsh
@@ -8,7 +8,7 @@ _rbenv() {
   local words completions
   read -cA words
 
-  emulate -LR zsh
+  emulate -L zsh
 
   if [ "${#words}" -eq 2 ]; then
     completions="$(rbenv commands)"

--- a/completions/rbenv.zsh
+++ b/completions/rbenv.zsh
@@ -8,6 +8,8 @@ _rbenv() {
   local words completions
   read -cA words
 
+  emulate -LR zsh
+
   if [ "${#words}" -eq 2 ]; then
     completions="$(rbenv commands)"
   else


### PR DESCRIPTION
While studying the `rbenv` codebase, I came across the `rbenv.zsh` tab completion file.  I noticed it indexes into an array of user-provided options [here](https://github.com/rbenv/rbenv/blob/master/completions/rbenv.zsh#L14), using `words[2, -2]`.  After some experimentation, I learned that `bash` uses 0-based indexing by default for its arrays, while `zsh` uses 1-based indexing.

As an experiment, I added an `echo` statement to see what the value of `words` would be:

```
if [[ ! -o interactive ]]; then
    return
fi

compctl -K _rbenv rbenv

_rbenv() {
  local words completions
  read -cA words

  echo "\nwords[2,-2]: ${words[2,-2]}"           # this is the only new line I added

  if [ "${#words}" -eq 2 ]; then
    completions="$(rbenv commands)"
  else
    completions="$(rbenv completions ${words[2,-2]})"
  fi

  reply=("${(ps:\n:)completions}")
}
```

According to [the zsh docs](https://zsh.sourceforge.io/Doc/Release/Options.html), the `KSH_ARRAYS` zsh shell option determines whether zsh uses 0-based or 1-based indexing.  Therefore, after adding the above `echo` statement and re-running `eval "$(rbenv init - zsh)"`, I then attempted rbenv tab completion twice: once after running `setopt KSH_ARRAYS`, and once after running `unsetopt KSH_ARRAYS`.  

<img width="486" alt="Screen Shot 2022-08-31 at 4 39 59 PM" src="https://user-images.githubusercontent.com/3839713/187803438-7ba060ee-f260-4e66-bff7-bbaa96127375.png">

When the user has `KSH_ARRAYS` unset, `words[2, -2]` will have one more value in it than when the option is set.  Therefore, if an `rbenv` user is running zsh and has changed their shell emulation by updating the `KSH_ARRAYS` option (perhaps because they prefer 0-based indexing), they may experience unexpected behavior in the options they see during tab completion.

This PR adds a line of code to the `_rbenv` function to use all zsh default options, but only within the scope of the function.  The options will be restored to the user's original preferences once the function scope is exited.  I tested this locally with the same steps that I used to reproduce the issue, and it results in `words[2, -2]` being evaluated the same regardless of whether I had run `setopt KSH_ARRAYS` or `unsetopt KSH_ARRAYS` just prior to execution:

<img width="484" alt="Screen Shot 2022-08-31 at 4 41 27 PM" src="https://user-images.githubusercontent.com/3839713/187803566-06924e0d-a914-4e82-871e-0e91fdb0b4f5.png">

Admittedly, I'm guessing most zsh users don't override their `KSH_ARRAYS` option, and I checked the Github history for this project and no one has created an issue to address this in its 10+-year history, so I wouldn't blame you if you considered this a solution in search of a problem.  This was mostly a learning experience for me as a journeyman open-source contributor, but I'm submitting the pull request anyway on the off-chance that you think it adds a greater-than-zero amount of value.  😊