### PR TITLE
Support GEM_HOME, add limited support for user-installed gems

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -104,6 +104,15 @@ list_executable_names() {
       echo "${file##*/}"
     done
   done
+  # list user-install'ed executables
+  for file in ~/.gem/ruby/*/bin/*; do
+    echo "${file##*/}"
+  done
+  if [ -n "$GEM_HOME" ]; then
+    for file in "$GEM_HOME"/bin/*; do
+      echo "${file##*/}"
+    done
+  fi
 }
 
 # The basename of each argument passed to `make_shims` will be

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -41,6 +41,17 @@ if [ "$RBENV_VERSION" = "system" ]; then
     RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
 else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
+  if [ ! -x "$RBENV_COMMAND_PATH" ]; then
+    # discover user-install'ed gem executables
+    if [ -n "$GEM_HOME" ]; then
+      user_install_path="${GEM_HOME}/bin/${RBENV_COMMAND}"
+    else
+      # FIXME: guessing this path is very fragile and works only for C Ruby
+      user_install_path="${HOME}/.gem/ruby/${RBENV_VERSION%.*}.0/bin/${RBENV_COMMAND}"
+    fi
+    [ -x "$user_install_path" ] && RBENV_COMMAND_PATH="$user_install_path"
+    unset user_install_path
+  fi
 fi
 
 OLDIFS="$IFS"

--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -37,6 +37,15 @@ else
   begin
     Gem.post_install(&hook)
     Gem.post_uninstall(&hook)
+
+    # Silence the warning that would be printed for --user-install'ed gems:
+    #
+    #   WARNING: You don't have ~/.gem/ruby/<version>/bin in your PATH,
+    #            gem executables will not run.
+    #
+    # This warning isn't accurate in the context of rbenv because the executables
+    # at this location will automatically be available for running through rbenv.
+    Gem::Installer.path_warning = true if Gem::Installer.respond_to?(:path_warning=)
   rescue
     warn "rbenv: error installing gem-rehash hooks (#{$!.class.name}: #{$!.message})"
   end

--- a/test/which.bats
+++ b/test/which.bats
@@ -98,6 +98,21 @@ The \`rspec' command exists in these Ruby versions:
 OUT
 }
 
+@test "executable found in user gems" {
+  create_executable "2.7.6" "ruby"
+  create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
+  GEM_HOME= RBENV_VERSION=2.7.6 run rbenv-which rake
+  assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
+}
+
+@test "executable found in gem home" {
+  create_executable "2.7.6" "ruby"
+  create_executable "${HOME}/mygems/bin" "rake"
+  create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
+  GEM_HOME="${HOME}/mygems" RBENV_VERSION=2.7.6 run rbenv-which rake
+  assert_success "${HOME}/mygems/bin/rake"
+}
+
 @test "carries original IFS within hooks" {
   create_hook which hello.bash <<SH
 hellos=(\$(printf "hello\\tugly world\\nagain"))

--- a/test/which.bats
+++ b/test/which.bats
@@ -101,7 +101,7 @@ OUT
 @test "executable found in user gems" {
   create_executable "2.7.6" "ruby"
   create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
-  GEM_HOME= RBENV_VERSION=2.7.6 run rbenv-which rake
+  GEM_HOME='' RBENV_VERSION=2.7.6 run rbenv-which rake
   assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
 }
 
@@ -133,6 +133,6 @@ SH
   mkdir -p "$RBENV_TEST_DIR"
   cd "$RBENV_TEST_DIR"
 
-  RBENV_VERSION= run rbenv-which ruby
+  RBENV_VERSION='' run rbenv-which ruby
   assert_success "${RBENV_ROOT}/versions/1.8/bin/ruby"
 }


### PR DESCRIPTION
The rehash operation will now discover and create shims for executables in additional locations:
- `~/.gem/ruby/<version>/bin/*`
- `$GEM_HOME/bin`

The `rbenv which` (and thus `rbenv exec`) command will also search these locations when looking up a command. This enables shims to dispatch calls to executables added by `GEM_HOME=/my/path gem install` or `gem install --user-install`.

Note that this support is limited:
- It will only work with C Ruby, as it's difficult to guess the `~/.gem/<engine>/<version>` directory for other Rubies without actually loading Ruby;
- It will only work for RBENV_VERSION values in the format `X.Y.Z` and not "system".

Fixes https://github.com/rbenv/rbenv/issues/1232, fixes https://github.com/rbenv/rbenv/issues/1382
Closes #639
Supersedes https://github.com/mislav/rbenv-user-gems