### PR TITLE
Switch back to resolving symlinks for `rbenv` executable

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -42,16 +42,39 @@ export RBENV_DIR
 shopt -s nullglob
 
 rbenv_bin="${BASH_SOURCE:-$0}"
-bin_path="$(cd "${rbenv_bin%/*}"/../libexec && pwd -P)"
+if [ -L "$rbenv_bin" ]; then
+  # resolve rbenv symlink to find out where the actual libexec directory is
+  readlink=$(type -p greadlink readlink 2>/dev/null | head -n1)
+  if [ -n "$readlink" ]; then
+    resolved="$($readlink "$rbenv_bin" 2>/dev/null)"
+    if [[ $resolved == /* ]]; then
+      libexec_dir="${resolved%/*}"
+    else
+      libexec_dir="$(cd "${rbenv_bin%/*}/${resolved%/*}" && pwd)"
+    fi
+  else
+    # no readlink available; assume rbenv project layout
+    libexec_dir="${rbenv_bin%/*}"
+    if [[ $libexec_dir == */* ]]; then
+      libexec_dir="${libexec_dir%/*}/libexec"
+    else
+      libexec_dir="${PWD}/libexec"
+    fi
+  fi
+else
+  libexec_dir="${rbenv_bin%/*}"
+  [[ $libexec_dir != "." ]] || libexec_dir="$PWD"
+fi
+
 for plugin_bin in "${RBENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+export PATH="${libexec_dir}:${PATH}"
 
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d"
-if [ "${bin_path%/*}" != "$RBENV_ROOT" ]; then
+if [ "${libexec_dir%/*}" != "$RBENV_ROOT" ]; then
   # Add rbenv's own `rbenv.d` unless rbenv was cloned to RBENV_ROOT
-  RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${bin_path%/*}/rbenv.d"
+  RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${libexec_dir%/*}/rbenv.d"
 fi
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do

--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -44,9 +44,8 @@ shopt -s nullglob
 rbenv_bin="${BASH_SOURCE:-$0}"
 if [ -L "$rbenv_bin" ]; then
   # resolve rbenv symlink to find out where the actual libexec directory is
-  readlink=$(type -p greadlink readlink 2>/dev/null | head -n1)
-  if [ -n "$readlink" ]; then
-    resolved="$($readlink "$rbenv_bin" 2>/dev/null)"
+  if readlink="$(type -p greadlink)" || readlink="$(type -p readlink)"; then
+    resolved="$("$readlink" "$rbenv_bin" 2>/dev/null)"
     if [[ $resolved == /* ]]; then
       libexec_dir="${resolved%/*}"
     else
@@ -72,7 +71,7 @@ done
 export PATH="${libexec_dir}:${PATH}"
 
 RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${RBENV_ROOT}/rbenv.d"
-if [ "${libexec_dir%/*}" != "$RBENV_ROOT" ]; then
+if [ ! "${libexec_dir%/*}"/rbenv.d -ef "$RBENV_ROOT"/rbenv.d ]; then
   # Add rbenv's own `rbenv.d` unless rbenv was cloned to RBENV_ROOT
   RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${libexec_dir%/*}/rbenv.d"
 fi

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -48,7 +48,7 @@ load test_helper
 
 @test "adds its own libexec to PATH" {
   run rbenv echo "PATH"
-  assert_success "${BATS_TEST_DIRNAME%/*}/libexec:$PATH"
+  assert_success "${BATS_TEST_DIRNAME}/../libexec:$PATH"
 }
 
 @test "adds plugin bin dirs to PATH" {
@@ -56,7 +56,7 @@ load test_helper
   mkdir -p "$RBENV_ROOT"/plugins/rbenv-each/bin
   run rbenv echo -F: "PATH"
   assert_success
-  assert_line 0 "${BATS_TEST_DIRNAME%/*}/libexec"
+  assert_line 0 "${BATS_TEST_DIRNAME}/../libexec"
   assert_line 1 "${RBENV_ROOT}/plugins/ruby-build/bin"
   assert_line 2 "${RBENV_ROOT}/plugins/rbenv-each/bin"
 }
@@ -72,5 +72,5 @@ load test_helper
 @test "RBENV_HOOK_PATH includes rbenv built-in plugins" {
   unset RBENV_HOOK_PATH
   run rbenv echo "RBENV_HOOK_PATH"
-  assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME%/*}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
+  assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME}/../rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 }


### PR DESCRIPTION
Considerations:

- `./libexec/rbenv` executable is the entrypoint to the program;

- BASH_SOURCE might be the path to a symlink that has activated `./libexec/rbenv`;

- We must resolve the symlink to learn where rbenv's libexec directory is;

- It's not guaranteed that rbenv commands will always remain directly under their own "libexec" directory, since a package maintainer can change that, e.g. rbenv commands are sometimes placed into `/usr/libexec/rbenv/*`;

- Resolving symlinks might fail and in that case we just assume rbenv project layout.

Fixes https://github.com/rbenv/rbenv/issues/1437 /cc @konsolebox

Reverts parts of https://github.com/rbenv/rbenv/pull/1428, therefore reintroducing ~4ms overhead at runtime to properly detect the location of rbenv scripts. I could not find a simpler way to do this; suggestions welcome!