### PR TITLE
Revert support for user-installed gems

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -104,10 +104,12 @@ list_executable_names() {
       echo "${file##*/}"
     done
   done
-  # list user-install'ed executables
-  for file in ~/.gem/ruby/*/bin/*; do
-    echo "${file##*/}"
-  done
+  if [ "$RBENV_USER_GEMS" != "0" ]; then
+    # list user-install'ed executables
+    for file in ~/.gem/ruby/*/bin/* "${XDG_DATA_HOME:-$HOME/.local/share}"/gem/ruby/*/bin/*; do
+      echo "${file##*/}"
+    done
+  fi
   if [ -n "$GEM_HOME" ]; then
     for file in "$GEM_HOME"/bin/*; do
       echo "${file##*/}"

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -104,12 +104,6 @@ list_executable_names() {
       echo "${file##*/}"
     done
   done
-  if [ "$RBENV_USER_GEMS" != "0" ]; then
-    # list user-install'ed executables
-    for file in ~/.gem/ruby/*/bin/* "${XDG_DATA_HOME:-$HOME/.local/share}"/gem/ruby/*/bin/*; do
-      echo "${file##*/}"
-    done
-  fi
   if [ -n "$GEM_HOME" ]; then
     for file in "$GEM_HOME"/bin/*; do
       echo "${file##*/}"

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -45,12 +45,17 @@ else
     # discover user-install'ed gem executables
     if [ -n "$GEM_HOME" ]; then
       user_install_path="${GEM_HOME}/bin/${RBENV_COMMAND}"
+    elif [ "$RBENV_USER_GEMS" != "0" ]; then
+      # https://github.com/rubygems/rubygems/blob/7e9afc48a6aa70cc4fcc2c378b387188098c5169/lib/rubygems/defaults.rb#L102-L108
+      # FIXME: guessing this path is somewhat fragile and works only for C Ruby
+      user_dir="${HOME}/.gem"
+      [ -e "$user_dir" ] || user_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gem"
+      user_install_path="${user_dir}/ruby/${RBENV_VERSION%.*}.0/bin/${RBENV_COMMAND}"
     else
-      # FIXME: guessing this path is very fragile and works only for C Ruby
-      user_install_path="${HOME}/.gem/ruby/${RBENV_VERSION%.*}.0/bin/${RBENV_COMMAND}"
+      user_install_path=""
     fi
     [ -x "$user_install_path" ] && RBENV_COMMAND_PATH="$user_install_path"
-    unset user_install_path
+    unset user_install_path user_dir
   fi
 fi
 

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -41,22 +41,29 @@ if [ "$RBENV_VERSION" = "system" ]; then
     RBENV_COMMAND_PATH="$(command -v "$RBENV_COMMAND" || true)"
 else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
-  if [ ! -x "$RBENV_COMMAND_PATH" ]; then
-    # discover user-install'ed gem executables
-    if [ -n "$GEM_HOME" ]; then
-      user_install_path="${GEM_HOME}/bin/${RBENV_COMMAND}"
-    elif [ "$RBENV_USER_GEMS" != "0" ]; then
-      # https://github.com/rubygems/rubygems/blob/7e9afc48a6aa70cc4fcc2c378b387188098c5169/lib/rubygems/defaults.rb#L102-L108
-      # FIXME: guessing this path is somewhat fragile and works only for C Ruby
-      user_dir="${HOME}/.gem"
-      [ -e "$user_dir" ] || user_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gem"
-      user_install_path="${user_dir}/ruby/${RBENV_VERSION%.*}.0/bin/${RBENV_COMMAND}"
-    else
-      user_install_path=""
+fi
+
+if [ ! -x "$RBENV_COMMAND_PATH" ]; then
+  # discover user-install'ed gem executables
+  user_install_path=""
+  if [ -n "$GEM_HOME" ]; then
+    user_install_path="${GEM_HOME}/bin/${RBENV_COMMAND}"
+  elif [ "$RBENV_USER_GEMS" != "0" ]; then
+    # https://github.com/rubygems/rubygems/blob/7e9afc48a6aa70cc4fcc2c378b387188098c5169/lib/rubygems/defaults.rb#L102-L108
+    # FIXME: guessing this path is somewhat fragile and works only when RBENV_VERSION is "X.Y.Z" or "X.Y" but not "system"
+    user_dir="${HOME}/.gem"
+    [ -e "$user_dir" ] || user_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gem"
+    user_install_version="$RBENV_VERSION"
+    if [[ $RBENV_VERSION == *.*.* ]]; then
+      user_install_version="${RBENV_VERSION%.*}.0"
+    elif [[ $RBENV_VERSION == *.* ]]; then
+      user_install_version="${RBENV_VERSION}.0"
     fi
-    [ -x "$user_install_path" ] && RBENV_COMMAND_PATH="$user_install_path"
-    unset user_install_path user_dir
+    user_install_path="${user_dir}/ruby/${user_install_version}/bin/${RBENV_COMMAND}"
+    unset user_dir user_install_version
   fi
+  [ ! -x "$user_install_path" ] || RBENV_COMMAND_PATH="$user_install_path"
+  unset user_install_path
 fi
 
 OLDIFS="$IFS"

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -43,27 +43,8 @@ else
   RBENV_COMMAND_PATH="${RBENV_ROOT}/versions/${RBENV_VERSION}/bin/${RBENV_COMMAND}"
 fi
 
-if [ ! -x "$RBENV_COMMAND_PATH" ]; then
-  # discover user-install'ed gem executables
-  user_install_path=""
-  if [ -n "$GEM_HOME" ]; then
-    user_install_path="${GEM_HOME}/bin/${RBENV_COMMAND}"
-  elif [ "$RBENV_USER_GEMS" != "0" ]; then
-    # https://github.com/rubygems/rubygems/blob/7e9afc48a6aa70cc4fcc2c378b387188098c5169/lib/rubygems/defaults.rb#L102-L108
-    # FIXME: guessing this path is somewhat fragile and works only when RBENV_VERSION is "X.Y.Z" or "X.Y" but not "system"
-    user_dir="${HOME}/.gem"
-    [ -e "$user_dir" ] || user_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gem"
-    user_install_version="$RBENV_VERSION"
-    if [[ $RBENV_VERSION == *.*.* ]]; then
-      user_install_version="${RBENV_VERSION%.*}.0"
-    elif [[ $RBENV_VERSION == *.* ]]; then
-      user_install_version="${RBENV_VERSION}.0"
-    fi
-    user_install_path="${user_dir}/ruby/${user_install_version}/bin/${RBENV_COMMAND}"
-    unset user_dir user_install_version
-  fi
-  [ ! -x "$user_install_path" ] || RBENV_COMMAND_PATH="$user_install_path"
-  unset user_install_path
+if [[ ! -x "$RBENV_COMMAND_PATH" && -n "$GEM_HOME" && -x "${GEM_HOME}/bin/${RBENV_COMMAND}" ]]; then
+  RBENV_COMMAND_PATH="${GEM_HOME}/bin/${RBENV_COMMAND}"
 fi
 
 OLDIFS="$IFS"

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -105,22 +105,17 @@ ruby
 OUT
 }
 
-@test "user-install" {
-  create_executable "${HOME}/.gem/ruby/3.0.0/bin/lolcat"
+@test "no shims for user-installed gems" {
+  create_executable "2.7.5" "ruby"
+  create_executable "3.1.2" "ruby"
+  create_executable "${HOME}/.gem/ruby/2.7.0/bin/lolcat"
   create_executable "${HOME}/.gem/ruby/3.1.0/bin/pinecone"
-
-  assert [ ! -e "${RBENV_ROOT}/shims/lolcat" ]
-  assert [ ! -e "${RBENV_ROOT}/shims/pinecone" ]
 
   run rbenv-rehash
   assert_success ""
 
-  run ls "${RBENV_ROOT}/shims"
-  assert_success
-  assert_output <<OUT
-lolcat
-pinecone
-OUT
+  assert [ ! -e "${RBENV_ROOT}/shims/lolcat" ]
+  assert [ ! -e "${RBENV_ROOT}/shims/pinecone" ]
 }
 
 @test "explicit gem home" {

--- a/test/which.bats
+++ b/test/which.bats
@@ -98,18 +98,11 @@ The \`rspec' command exists in these Ruby versions:
 OUT
 }
 
-@test "executable found in user gems" {
+@test "executable not found in user gems" {
   create_executable "2.7.6" "ruby"
   create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
   GEM_HOME='' RBENV_VERSION=2.7.6 run rbenv-which rake
-  assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
-}
-
-@test "executable found in user gems (short version string)" {
-  create_executable "2.7.6" "ruby"
-  create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
-  GEM_HOME='' RBENV_VERSION=2.7 run rbenv-which rake
-  assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
+  assert_failure
 }
 
 @test "executable found in gem home" {

--- a/test/which.bats
+++ b/test/which.bats
@@ -105,12 +105,26 @@ OUT
   assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
 }
 
+@test "executable found in user gems (short version string)" {
+  create_executable "2.7.6" "ruby"
+  create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
+  GEM_HOME='' RBENV_VERSION=2.7 run rbenv-which rake
+  assert_success "${HOME}/.gem/ruby/2.7.0/bin/rake"
+}
+
 @test "executable found in gem home" {
   create_executable "2.7.6" "ruby"
   create_executable "${HOME}/mygems/bin" "rake"
   create_executable "${HOME}/.gem/ruby/2.7.0/bin" "rake"
   GEM_HOME="${HOME}/mygems" RBENV_VERSION=2.7.6 run rbenv-which rake
   assert_success "${HOME}/mygems/bin/rake"
+}
+
+@test "executable found in gem home (system ruby)" {
+  create_executable "${HOME}/mygems/bin" "rbenv-test-lolcat"
+  create_executable "${HOME}/.gem/ruby/2.6.0/bin" "rbenv-test-lolcat"
+  GEM_HOME="${HOME}/mygems" RBENV_VERSION=system run rbenv-which rbenv-test-lolcat
+  assert_success "${HOME}/mygems/bin/rbenv-test-lolcat"
 }
 
 @test "carries original IFS within hooks" {


### PR DESCRIPTION
This removes support for discovering executables installed with `gem install --user-install`. The logic for determining the correct `~/.gem/<engine>/<version>/bin` directory was brittle, replicated too much logic from Rubygems internals (including support for XDG_DATA_HOME), and was ultimately not forwards-compatible with future versions of Rubygems.

The only way I can imagine to precisely determine the correct installation directory is to actually invoke `ruby -r rubygems -e 'puts Gem.user_dir', which on my machine takes at minimum 30ms to complete, which would be unacceptable to add to the overhead of rbenv shims.

Shell-integrated Ruby version managers such as chruby or direnv are generally better at discovering this directory and adding it to PATH inside the current shell session. https://github.com/rbenv/rbenv/wiki/Comparison-of-version-managers

The support for GEM_HOME, however, is kept and improved to also work for `system` Ruby.

Fixes https://github.com/rbenv/rbenv/issues/1442