### PR TITLE
Ignore shell builtins and functions when looking up commands in PATH

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -99,7 +99,7 @@ case "$command" in
   exec rbenv-help
   ;;
 * )
-  command_path="$(command -v "rbenv-$command" || true)"
+  command_path="$(type -P "rbenv-$command" || true)"
   if [ -z "$command_path" ]; then
     if [ "$command" == "shell" ]; then
       abort "shell integration not enabled. Run \`rbenv init' for instructions."

--- a/libexec/rbenv-completions
+++ b/libexec/rbenv-completions
@@ -15,7 +15,7 @@ if [ "$COMMAND" = "--complete" ]; then
   exec rbenv-commands
 fi
 
-COMMAND_PATH="$(command -v "rbenv-$COMMAND" || command -v "rbenv-sh-$COMMAND")"
+COMMAND_PATH="$(type -P "rbenv-$COMMAND" "rbenv-sh-$COMMAND" | head -n1)"
 
 # --help is provided automatically
 echo --help

--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -23,7 +23,7 @@ fi
 
 command_path() {
   local command="$1"
-  command -v rbenv-"$command" || command -v rbenv-sh-"$command" || true
+  type -P rbenv-"$command" rbenv-sh-"$command" | head -n1
 }
 
 extract_initial_comment_block() {

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -47,7 +47,7 @@ root="${root%/*}"
 
 rbenv_in_path=true
 if [ -n "$RBENV_ORIG_PATH" ]; then
-  PATH="$RBENV_ORIG_PATH" command -v rbenv >/dev/null || rbenv_in_path=""
+  PATH="$RBENV_ORIG_PATH" type -P rbenv >/dev/null || rbenv_in_path=""
 fi
 
 if [ -z "$print" ]; then

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -38,7 +38,7 @@ remove_prototype_shim() {
 # absolute path to the rbenv executable itself.
 rbenv_path() {
   local found
-  found="$(PATH="$RBENV_ORIG_PATH" command -v rbenv)"
+  found="$(PATH="$RBENV_ORIG_PATH" type -P rbenv)"
   if [[ $found == /* ]]; then
     echo "$found"
   elif [[ -n "$found" ]]; then


### PR DESCRIPTION
Weirdly, `command -v true` returns `true` instead of `/usr/bin/true`.

Followup to https://github.com/rbenv/rbenv/pull/1440