### PR TITLE
Avoid assuming rbenv original project layout

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -45,8 +45,7 @@ rbenv_path() {
     echo "$PWD/${found#./}"
   else
     # Assume rbenv isn't in PATH.
-    local here="${BASH_SOURCE%/*}"
-    echo "${here%/*}/bin/rbenv"
+    echo "${BASH_SOURCE%/*}/rbenv"
   fi
 }
 


### PR DESCRIPTION
Someone packaging rbenv might choose to place the `bin` and `libexec` directories separately.

Ref. https://github.com/rbenv/rbenv/issues/1437