### PR TITLE
Use `read -a` to split output into an array

### DIFF
--- a/libexec/rbenv-commands
+++ b/libexec/rbenv-commands
@@ -20,7 +20,7 @@ elif [ "$1" = "--no-sh" ]; then
   shift
 fi
 
-IFS=: paths=($PATH)
+IFS=: read -d '' -r -a paths <<<"$PATH" || true
 
 shopt -s nullglob
 

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -33,7 +33,7 @@ export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks exec)"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks exec)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -33,10 +33,9 @@ export RBENV_VERSION
 RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks exec`)
-IFS="$OLDIFS"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks exec)"
 for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
   source "$script"
 done
 

--- a/libexec/rbenv-hooks
+++ b/libexec/rbenv-hooks
@@ -21,7 +21,7 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
-IFS=: hook_paths=($RBENV_HOOK_PATH)
+IFS=: read -r -a hook_paths <<<"$RBENV_HOOK_PATH"
 
 shopt -s nullglob
 for path in "${hook_paths[@]}"; do

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -126,7 +126,7 @@ if [ -z "$no_rehash" ]; then
   echo 'command rbenv rehash 2>/dev/null'
 fi
 
-read -d '' -r -a commands <<<"$(rbenv-commands --sh)" || true
+IFS=$'\n' read -d '' -r -a commands <<<"$(rbenv-commands --sh)" || true
 
 case "$shell" in
 fish )

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -126,7 +126,8 @@ if [ -z "$no_rehash" ]; then
   echo 'command rbenv rehash 2>/dev/null'
 fi
 
-commands=(`rbenv-commands --sh`)
+read -d '' -r -a commands <<<"$(rbenv-commands --sh)" || true
+
 case "$shell" in
 fish )
   cat <<EOS

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -160,7 +160,7 @@ remove_outdated_shims
 registered_shims=( $(list_executable_names | sort -u) )
 
 # Allow plugins to register shims.
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks rehash)"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks rehash)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -160,11 +160,9 @@ remove_outdated_shims
 registered_shims=( $(list_executable_names | sort -u) )
 
 # Allow plugins to register shims.
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks rehash`)
-IFS="$OLDIFS"
-
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks rehash)"
 for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
   source "$script"
 done
 

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -8,7 +8,7 @@ if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-name)"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-name)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -8,10 +8,9 @@ if [ -z "$RBENV_VERSION" ]; then
   RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks version-name`)
-IFS="$OLDIFS"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-name)"
 for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
   source "$script"
 done
 

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -5,10 +5,9 @@ set -e
 
 unset RBENV_VERSION_ORIGIN
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks version-origin`)
-IFS="$OLDIFS"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-origin)"
 for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
   source "$script"
 done
 

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -5,7 +5,7 @@ set -e
 
 unset RBENV_VERSION_ORIGIN
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-origin)"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-origin)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -47,7 +47,7 @@ if [[ ! -x "$RBENV_COMMAND_PATH" && -n "$GEM_HOME" && -x "${GEM_HOME}/bin/${RBEN
   RBENV_COMMAND_PATH="${GEM_HOME}/bin/${RBENV_COMMAND}"
 fi
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks which)"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks which)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -47,10 +47,9 @@ if [[ ! -x "$RBENV_COMMAND_PATH" && -n "$GEM_HOME" && -x "${GEM_HOME}/bin/${RBEN
   RBENV_COMMAND_PATH="${GEM_HOME}/bin/${RBENV_COMMAND}"
 fi
 
-OLDIFS="$IFS"
-IFS=$'\n' scripts=(`rbenv-hooks which`)
-IFS="$OLDIFS"
+IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks which)"
 for script in "${scripts[@]}"; do
+  # shellcheck disable=SC1090
   source "$script"
 done
 


### PR DESCRIPTION
This avoids shellcheck warnings about using the `(...)` array notation to split captured output into an array.