### PR TITLE
Check every shim in SHIM_PATH instead of just the first one; break once the first diff is found

### DIFF
--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -90,8 +90,8 @@ remove_outdated_shims() {
   for shim in "$SHIM_PATH"/*; do
     if ! diff "$PROTOTYPE_SHIM_PATH" "$shim" >/dev/null 2>&1; then
       rm -f "$SHIM_PATH"/*
+      break
     fi
-    break
   done
 }
 

--- a/libexec/rbenv-rehash
+++ b/libexec/rbenv-rehash
@@ -111,23 +111,7 @@ list_executable_names() {
   fi
 }
 
-# The basename of each argument passed to `make_shims` will be
-# registered for installation as a shim. In this way, plugins may call
-# `make_shims` with a glob to register many shims at once.
-make_shims() {
-  local file shim
-  for file; do
-    shim="${file##*/}"
-    registered_shims+=("$shim")
-  done
-}
-
-# Registers the name of a shim to be generated.
-register_shim() {
-  registered_shims+=("$1")
-}
-
-# Install all the shims registered via `make_shims` or `register_shim` directly.
+# Install all the shims registered via `register_shims` directly.
 install_registered_shims() {
   local shim file
   for shim in "${registered_shims[@]}"; do


### PR DESCRIPTION
**TL;DR:**
If we only check the first shim in the `SHIM_PATH` directory for diffing (and therefore removal), we might miss some edge cases (for example, if there's no diff w/ the first file but there is a diff with subsequent files).  This PR changes the `remove_outdated_shims` function so that it checks each shim against the prototype, and if it finds a diff, it removes all the shim files and breaks out of the loop.

As a side note, this PR also removes two functions which are no longer used in `rbenv-rehash`.

**UPDATE:**
I now understand the meaning of the comments above `remove_outdated_shims` to mean that we are intentionally only checking the first shim in the `SHIM_PATH` directory.  That said, is there a chance that the `install_registered_shims` function could fail mid-way through, updating the first shim(s) in the `SHIM_PATH` but leaving subsequent shims un-replaced?

If so, I would think a subsequent call to `rbenv rehash` would not perform as expected as long as we're only checking the first shim file, in which case does it make sense to check the diffs of all the shim files, not just the first one?  There might be a small chance of that happening, but the question is how bad is the result if it does happen.  It seems to me like being unable to update those remaining shims would be a pretty bad result indeed, but y'all are the experts so I defer to you.

I'm guessing that `diff`ing only the first shim in the directory is a performance optimization, which makes sense. For what it's worth, I ran this experiment on my local machine and (subjectively) it didn't feel especially slow to `diff` on all the gems, but then I only have 97 gems currently installed in `~/.rbenv/shims/` so I'm probably not the p99 power-user that you'd want to perf test this against.

**Details:**
It's quite possible I'm in the wrong here, but the way [this line of code](https://github.com/rbenv/rbenv/blob/c4395e58201966d9f90c12bd6b7342e389e7a4cb/libexec/rbenv-rehash#L94) reads to me, it seems like the `break` statement should be inside the `if` check, shouldn't it?  As it's currently written, it seems to always `break` after the first iteration of the `for`-loop.  I think I replicated this phenomenon locally, via the following:

<img width="621" alt="Screen Shot 2022-10-08 at 12 54 11 PM" src="https://user-images.githubusercontent.com/3839713/194720924-4a66594d-4074-423b-a297-987e368ef74e.png">

Here I do the following:


 - I create a prototype file containing the character “a”,
 - I make a directory named `shims` with 4 text files, 3 of which match the prototype and one of which does not.
 - I then paste an identical `remove_outdated_shims` function into the shell, with only some extra loglines and a counter variable added.
 - I increment the counter before every run and log the count # to the screen.
 - Lastly, I call the function in the terminal with the appropriate env var values set for `$SHIM_PATH` and `PROTOTYPE_SHIM_PATH`.

In my shell function, the counter only outputs once, and we never see the `about to delete all shims` logline, meaning we didn’t reach the shim whose contents differ from the prototype.  Am I missing something, or is this a bug in the code?

Just in case, here's a PR to address the issue.  If the code already works as intended, I'd love to know what piece of info I appear to be missing.  Thanks for maintaining a great tool.