### PR TITLE
`rbenv version`- test coverage for preferring local over global version file

### DIFF
--- a/test/version.bats
+++ b/test/version.bats
@@ -36,3 +36,12 @@ setup() {
   run rbenv-version
   assert_success "1.9.3 (set by ${RBENV_ROOT}/version)"
 }
+
+@test "prefer local over global file" {
+  create_version "1.9.3"
+  create_version "3.0.0"
+  cat > ".ruby-version" <<<"1.9.3"
+  cat > "${RBENV_ROOT}/version" <<<"3.0.0"
+  run rbenv-version
+  assert_success "1.9.3 (set by ${PWD}/.ruby-version)"
+}


### PR DESCRIPTION
While reading the `version.bats` file, I noticed that we have the following two specs:

```
@test "set by local file" {
  create_version "1.9.3"
  cat > ".ruby-version" <<<"1.9.3"
  run rbenv-version
  assert_success "1.9.3 (set by ${PWD}/.ruby-version)"
}

@test "set by global file" {
  create_version "1.9.3"
  cat > "${RBENV_ROOT}/version" <<<"1.9.3"
  run rbenv-version
  assert_success "1.9.3 (set by ${RBENV_ROOT}/version)"
}
```

These tests ensure that RBENV is able to either a) pull the version from the local `.ruby-version` file, or b) pull it from the global "${RBENV_ROOT}/version" file.  However I notice that there's no test to assert which should be favored over the other, if both exist.  In the spirit of ["tests as executable documentation"](https://softwareengineering.stackexchange.com/questions/154615/are-unit-tests-really-used-as-documentation), this seems like a useful addition.

This PR adds that additional test.