### PR TITLE
Update actions/checkout version to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install bats
       run: git clone --depth 1 https://github.com/sstephenson/bats.git
     - name: Run tests


### PR DESCRIPTION
The version 3.x appears to be due to the following:
- https://github.com/actions/checkout/pull/689

There have been no breaking changes, and we seem to have no problem keeping up with the latest version.