### PR TITLE
ci(lint): pin `differential-shellcheck` to `v3` tag

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@latest
+        uses: redhat-plumbers-in-action/differential-shellcheck@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Please consider using the `v3` tag instead of `latest`. We expect that a new major release could break the API of the `differential-shellcheck` GitHub Action.

Related to:

- https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/156