### PR TITLE
Do not rely on /usr/bin/env in critical paths

### DIFF
--- a/libexec/rbenv-exec
+++ b/libexec/rbenv-exec
@@ -21,7 +21,7 @@ if [ "$1" = "--complete" ]; then
   exec rbenv-shims --short
 fi
 
-RBENV_VERSION="$(rbenv-version-name)"
+RBENV_VERSION="$($BASH rbenv-version-name)"
 RBENV_COMMAND="$1"
 
 if [ -z "$RBENV_COMMAND" ]; then
@@ -30,10 +30,10 @@ if [ -z "$RBENV_COMMAND" ]; then
 fi
 
 export RBENV_VERSION
-RBENV_COMMAND_PATH="$(rbenv-which "$RBENV_COMMAND")"
+RBENV_COMMAND_PATH="$($BASH rbenv-which "$RBENV_COMMAND")"
 RBENV_BIN_PATH="${RBENV_COMMAND_PATH%/*}"
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks exec)" || true
+IFS=$'\n' read -d '' -r -a scripts <<<"$($BASH rbenv-hooks exec)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"

--- a/libexec/rbenv-prefix
+++ b/libexec/rbenv-prefix
@@ -18,11 +18,11 @@ fi
 if [ -n "$1" ]; then
   export RBENV_VERSION="$1"
 elif [ -z "$RBENV_VERSION" ]; then
-  RBENV_VERSION="$(rbenv-version-name)"
+  RBENV_VERSION="$($BASH rbenv-version-name)"
 fi
 
 if [ "$RBENV_VERSION" = "system" ]; then
-  if RUBY_PATH="$(rbenv-which ruby)"; then
+  if RUBY_PATH="$($BASH rbenv-which ruby)"; then
     RUBY_PATH="${RUBY_PATH%/*}"
     RBENV_PREFIX_PATH="${RUBY_PATH%/bin}"
     echo "${RBENV_PREFIX_PATH:-/}"

--- a/libexec/rbenv-version-name
+++ b/libexec/rbenv-version-name
@@ -4,11 +4,11 @@ set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
 if [ -z "$RBENV_VERSION" ]; then
-  RBENV_VERSION_FILE="$(rbenv-version-file)"
-  RBENV_VERSION="$(rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
+  RBENV_VERSION_FILE="$($BASH rbenv-version-file)"
+  RBENV_VERSION="$($BASH rbenv-version-file-read "$RBENV_VERSION_FILE" || true)"
 fi
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-name)" || true
+IFS=$'\n' read -d '' -r -a scripts <<<"$($BASH rbenv-hooks version-name)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"
@@ -29,6 +29,6 @@ if version_exists "$RBENV_VERSION"; then
 elif version_exists "${RBENV_VERSION#ruby-}"; then
   echo "${RBENV_VERSION#ruby-}"
 else
-  echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $(rbenv-version-origin))" >&2
+  echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $($BASH rbenv-version-origin))" >&2
   exit 1
 fi

--- a/libexec/rbenv-version-origin
+++ b/libexec/rbenv-version-origin
@@ -5,7 +5,7 @@ set -e
 
 unset RBENV_VERSION_ORIGIN
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks version-origin)" || true
+IFS=$'\n' read -d '' -r -a scripts <<<"$($BASH rbenv-hooks version-origin)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"
@@ -16,5 +16,5 @@ if [ -n "$RBENV_VERSION_ORIGIN" ]; then
 elif [ -n "$RBENV_VERSION" ]; then
   echo "RBENV_VERSION environment variable"
 else
-  rbenv-version-file
+  $BASH rbenv-version-file
 fi

--- a/libexec/rbenv-whence
+++ b/libexec/rbenv-whence
@@ -20,8 +20,8 @@ fi
 
 whence() {
   local command="$1"
-  rbenv-versions --bare | while read -r version; do
-    path="$(rbenv-prefix "$version")/bin/${command}"
+  $BASH rbenv-versions --bare | while read -r version; do
+    path="$($BASH rbenv-prefix "$version")/bin/${command}"
     if [ -x "$path" ]; then
       [ "$print_paths" ] && echo "$path" || echo "$version"
     fi

--- a/libexec/rbenv-which
+++ b/libexec/rbenv-which
@@ -34,7 +34,7 @@ if [ -z "$RBENV_COMMAND" ]; then
   exit 1
 fi
 
-RBENV_VERSION="${RBENV_VERSION:-$(rbenv-version-name)}"
+RBENV_VERSION="${RBENV_VERSION:-$($BASH rbenv-version-name)}"
 
 if [ "$RBENV_VERSION" = "system" ]; then
   PATH="$(remove_from_path "${RBENV_ROOT}/shims")" \
@@ -47,7 +47,7 @@ if [[ ! -x "$RBENV_COMMAND_PATH" && -n "$GEM_HOME" && -x "${GEM_HOME}/bin/${RBEN
   RBENV_COMMAND_PATH="${GEM_HOME}/bin/${RBENV_COMMAND}"
 fi
 
-IFS=$'\n' read -d '' -r -a scripts <<<"$(rbenv-hooks which)" || true
+IFS=$'\n' read -d '' -r -a scripts <<<"$($BASH rbenv-hooks which)" || true
 for script in "${scripts[@]}"; do
   # shellcheck disable=SC1090
   source "$script"
@@ -56,12 +56,12 @@ done
 if [ -x "$RBENV_COMMAND_PATH" ]; then
   echo "$RBENV_COMMAND_PATH"
 elif [ "$RBENV_VERSION" != "system" ] && [ ! -d "${RBENV_ROOT}/versions/${RBENV_VERSION}" ]; then
-  echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $(rbenv-version-origin))" >&2
+  echo "rbenv: version \`$RBENV_VERSION' is not installed (set by $($BASH rbenv-version-origin))" >&2
   exit 1
 else
   echo "rbenv: $RBENV_COMMAND: command not found" >&2
 
-  versions="$(rbenv-whence "$RBENV_COMMAND" || true)"
+  versions="$($BASH rbenv-whence "$RBENV_COMMAND" || true)"
   if [ -n "$versions" ]; then
     { echo
       echo "The \`$1' command exists in these Ruby versions:"


### PR DESCRIPTION
rbenv uses a lot of sub shell script calls, and `#!/usr/bin/env bash` is executed each time. This is not very efficient depending on the PATH settings.

This changeset is to use `$BASH rbenv-*` when calling `rbenv-*` in critical paths to invoke ruby. This eliminates the overhead of calling `/usr/bin/env`.

Before:
```
$ time ruby -v
ruby 3.3.0dev (2023-02-20T01:33:06Z master 7d5794bad5) [x86_64-linux]

real    0m0.532s
user    0m0.022s
sys     0m0.087s
```

After:
```
$ time ruby -v
ruby 3.3.0dev (2023-02-20T01:33:06Z master 7d5794bad5) [x86_64-linux]

real    0m0.204s
user    0m0.018s
sys     0m0.028s
```