### PR TITLE
Prefer readlink to greadlink

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -41,7 +41,7 @@ export RBENV_DIR
 
 canonicalize() {
   local readlink resolved_path
-  if readlink="$(type -P greadlink)" || readlink="$(type -P readlink)"; then
+  if readlink="$(type -P readlink)" || readlink="$(type -P greadlink)"; then
     # happy path: GNU & BSD readlink, macOS 12.3+
     if resolved_path="$("$readlink" -f "$1" 2>/dev/null)"; then
       printf "%s\n" "$resolved_path"


### PR DESCRIPTION
Previously, rbenv tries to find `greadlink` and then `readlink`. However, there is usually no `greadlink` in Linux. Looking for `greadlink` could be a significant overhead on some environments where `PATH` contains many directories.

Ubuntu on WSL2 is just such an environment. Looking for `readlink` before `greadlink` speeds up ruby startup.

Before this change:

```
$ time ruby -v
ruby 3.3.0dev (2023-02-20T01:33:06Z master 7d5794bad5) [x86_64-linux]

real    0m0.532s
user    0m0.022s
sys     0m0.087s
```

After this change:

```
$ time ruby -v
ruby 3.3.0dev (2023-02-20T01:33:06Z master 7d5794bad5) [x86_64-linux]

real    0m0.419s
user    0m0.042s
sys     0m0.055s
```