### PR TITLE
Add rbenv.bats spec to cover the case when RBENV_DIR does not contain a forward slash

### DIFF
--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -38,6 +38,11 @@ load test_helper
   assert_output "$dir"
 }
 
+@test "inherited RBENV_DIR without a '/' char" {
+  RBENV_DIR="." run rbenv echo RBENV_DIR
+  assert_output "$(pwd)"
+}
+
 @test "invalid RBENV_DIR" {
   dir="${BATS_TMPDIR}/does-not-exist"
   assert [ ! -d "$dir" ]


### PR DESCRIPTION
While comparing the specs in `rbenv.bats` with the code in `libexec/rbenv`, I noticed that [this spec](https://github.com/rbenv/rbenv/blob/master/test/rbenv.bats#L34) appears to cover the first half of the `||` condition, when `RBENV_DIR` does contain the `/` character:

```
[[ $RBENV_DIR == /* ]] ...
```

But there doesn't appear to be an equivalent test for the 2nd half of that `||` condition:

```
... || RBENV_DIR="$PWD/$RBENV_DIR"
```

This PR adds a test to cover that code path.