### PR TITLE
Add spec to cover inclusion of etc/ sub-folders in plugins test

### DIFF
--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -59,7 +59,9 @@ load test_helper
   assert_line 0 "${BATS_TEST_DIRNAME%/*}/libexec"
   assert_line 1 "${RBENV_ROOT}/plugins/ruby-build/bin"
   assert_line 2 "${RBENV_ROOT}/plugins/rbenv-each/bin"
+}
 
+@test "RBENV_HOOK_PATH includes etc/rbenv.d folders" {
   mkdir -p "$RBENV_ROOT"/plugins/rbenv-foo/etc/rbenv.d
   run rbenv echo -F: "RBENV_HOOK_PATH"
   assert_line 6 "${RBENV_ROOT}/plugins/rbenv-foo/etc/rbenv.d"


### PR DESCRIPTION
I noticed that [this block of code](https://github.com/rbenv/rbenv/blob/master/libexec/rbenv#L86-L88) in `libexec/rbenv` appeared to be untested.  When I commented it out, both `test/rbenv.bats` and `test/hooks.bats` continued to pass.

This new test ensures that `libexec/rbenv.bats` fails when the above block is commented-out, and passes when it's un-commented.