### PR TITLE
Remove redundant `RBENV_DIR` assignment

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -32,7 +32,6 @@ if [ -z "${RBENV_DIR}" ]; then
 else
   [[ $RBENV_DIR == /* ]] || RBENV_DIR="$PWD/$RBENV_DIR"
   cd "$RBENV_DIR" 2>/dev/null || abort "cannot change working directory to \`$RBENV_DIR'"
-  RBENV_DIR="$PWD"
   cd "$OLDPWD"
 fi
 export RBENV_DIR


### PR DESCRIPTION
This 2nd assignment of `RBENV_DIR` to `"$PWD"` appears to be redundant, because we already call...

```
[[ $RBENV_DIR == /* ]] || RBENV_DIR="$PWD/$RBENV_DIR"
```

...two lines prior.

The code in its current form:

 - assigns `RBENV_DIR` to `"$PWD/$RBENV_DIR"`,
 - `cd`s into that new `RBENV_DIR`, and finally
 - re-assigns `RBENV_DIR` to the value that it was just set to
 
This might be a relic from [this PR](https://github.com/rbenv/rbenv/pull/985/files), which added the 1st assignment but didn't remove the 2nd one.  