### PR TITLE
ci: trigger differential-shellcheck workflow on push

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@
 
 name: Lint
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
 
@@ -11,6 +13,9 @@ permissions:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
 
     steps:
       - name: Repository checkout


### PR DESCRIPTION
Fixes: https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/215

This should get rid of annoying messages from the `github-code-scanning` bot.

![Screenshot from 2023-03-22 07-00-32](https://user-images.githubusercontent.com/2879818/226815668-36272095-4f1d-4465-a0e8-f317b0abfc52.png)

Also, I have added the required permission for uploading SARIF reports to GitHub
