### PR TITLE
Support ksh versions

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -62,7 +62,12 @@ if [ -z "$print" ]; then
   zsh )
     profile='~/.zshrc'
     ;;
-  ksh | ksh93 | ksh88 | pdksh | mksh )
+  ksh | ksh93 | mksh )
+    # There are two implementations of Korn shell: AT&T (ksh93) and Mir (mksh).
+    # Systems may have them installed under those names, or as ksh, so those
+    # are recognized here. The obsolete ksh88 (subsumed by ksh93) and pdksh
+    # (subsumed by mksh) are not included, since they are unlikely to still
+    # be in use as interactive shells anywhere.
     profile='~/.profile'
     ;;
   fish )
@@ -144,7 +149,7 @@ function rbenv
 end
 EOS
   ;;
-ksh | ksh93 | ksh88 | pdksh | mksh )
+ksh | ksh93 | mksh )
   cat <<EOS
 function rbenv {
   typeset command

--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -62,7 +62,7 @@ if [ -z "$print" ]; then
   zsh )
     profile='~/.zshrc'
     ;;
-  ksh )
+  ksh | ksh93 | ksh88 | pdksh | mksh )
     profile='~/.profile'
     ;;
   fish )
@@ -144,7 +144,7 @@ function rbenv
 end
 EOS
   ;;
-ksh )
+ksh | ksh93 | ksh88 | pdksh | mksh )
   cat <<EOS
 function rbenv {
   typeset command


### PR DESCRIPTION
Some systems have ksh installed under the name `ksh93`. A few others use the  `mksh` implementation, originated before ksh was open source. Both of these can be found in multiple Linux distribution package managers, and may install under those names and/or as `ksh`.

As far as the (very minor) use in rbenv is concerned, these are all equivalent. This change accepts all of the above.

Tested with `ksh93` and `mksh`.