### PR TITLE
version-file docs update

### DIFF
--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Usage: rbenv version-file [<dir>]
-# Summary: Detect the file that sets the current rbenv version
+# Summary: Detect the file that sets the current rbenv version.
+#
+# Prints locations of existing files, but also prints a location
+# of a file that, when created, would have dictated the version.
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Usage: rbenv version-file [<dir>]
-# Summary: Detect the file that sets the current rbenv version.
+# Summary: Detect the file that sets the current rbenv version
 #
-# Prints locations of existing files.  If no file found, prints a location
-# of a file that, when created, would have dictated the version.
+# Detects and prints the location of a `.ruby-version` file that sets the
+# version for the current working directory. If no file found, this prints
+# the location of the global version file, even if that file does
+# not exist.
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x

--- a/libexec/rbenv-version-file
+++ b/libexec/rbenv-version-file
@@ -2,8 +2,9 @@
 # Usage: rbenv version-file [<dir>]
 # Summary: Detect the file that sets the current rbenv version.
 #
-# Prints locations of existing files, but also prints a location
+# Prints locations of existing files.  If no file found, prints a location
 # of a file that, when created, would have dictated the version.
+
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 


### PR DESCRIPTION
The job of the `rbenv-version-file` command is to print the filepath for the file which sets the current Ruby version.  It searches for a `.ruby-version` file, traversing upward if such a file is not found until it reaches the root directory.

 - If a directory is passed as an argument, the command uses that directory as a starting point.
 - If no directory is passed as an argument:
   - The command first searches in `RBENV_DIR`.
   - If no `.ruby-version` file is found, it searches again in the current directory (provided that `RBENV_DIR` is different from the current directory).
   - If both of those attempts fail to find a `.ruby-version` file, it prints the path to RBENV's global version file (`"${RBENV_ROOT}/version"`).

This global version file may not actually exist, for example in the following cases:

 - If a user has not yet set a global version via `rbenv global <version_number>`.
 - If they have not set a local project version, either via `rbenv local <version_number>` or by manually creating a `.ruby-version` file.

In the case where the filepath returned by `rbenv-version-file` doesn't actually exist, the result might be confusion on the user's part.  This PR attempts to address that confusion, by updating the output of `rbenv help version-file` to specify that this command's output is the filepath which *would* set the Ruby version, *if* it exists.