### PR TITLE
Rescue from errors during post-install rehash hook in `rubygems_plugin.rb`

### DIFF
--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -1,9 +1,16 @@
+require 'open3'
+
+class CouldNotRehashError < StandardError; end;
+
 hook = lambda do |installer|
   begin
     # Ignore gems that aren't installed in locations that rbenv searches for binstubs
     if installer.spec.executables.any? &&
         [Gem.default_bindir, Gem.bindir(Gem.user_dir)].include?(installer.bin_dir)
-      `rbenv rehash`
+      stdout, stderr, status = Open3.capture3("rbenv rehash")
+      if stderr
+        raise CouldNotRehashError, stderr
+      end
     end
   rescue
     warn "rbenv: error in gem-rehash (#{$!.class.name}: #{$!.message})"


### PR DESCRIPTION
Ruby backtick syntax does not raise exceptions if a non-zero exit code is returned by the command inside the backticks.  This means we never reach inside the `rescue` block of `rubygems_plugin.rb`'s hook lambda if the `rbenv rehash` command errors out (although we *will* still see any output that `rbenv-rehash` prints to `stderr`).

We can demonstrate this by purposely creating the rehash lock file, and attempting to install a gem which includes an executable:

```
$ touch ~/.rbenv/shims/.rbenv-shim

$ gem install wisper   
rbenv: cannot rehash: /Users/richiethomas/.rbenv/shims/.rbenv-shim exists
Successfully installed wisper-2.0.1
Parsing documentation for wisper-2.0.1
Done installing documentation for wisper after 0 seconds
1 gem installed
```

We can see that `rbenv: cannot rehash: /Users/richiethomas/.rbenv/shims/.rbenv-shim exists` printed to `stderr`, but the warning text, error class name, etc. inside the rescue block (i.e. `rbenv: error in gem-rehash ...`) is not printed.

This issue can be fixed using the Ruby standard library's `Open3` module, which runs a command taken from an argument, and returns the output from `stdout` and `stderr`.  If any `stderr` text exists, we can raise an exception with said text, and rescue with the expected warning message.

With this in place, we now see the following output:

```
$ gem install wisper
rbenv: error in gem-rehash (CouldNotRehashError: rbenv: cannot rehash: /Users/richiethomas/.rbenv/shims/.rbenv-shim exists
)
Successfully installed wisper-2.0.1
Parsing documentation for wisper-2.0.1
Done installing documentation for wisper after 0 seconds
1 gem installed
```

Note that I did also try a non-backtick invocation of `rbenv rehash`, i.e. `system "rbenv rehash"`, but this similarly failed to raise an exception.

More info on Open3 here- https://docs.ruby-lang.org/en/2.0.0/Open3.html
Official module repo here- https://github.com/ruby/open3
