### PR TITLE
Clear command history after 'rbenv rehash' in Fish shell

### DIFF
--- a/libexec/rbenv-sh-rehash
+++ b/libexec/rbenv-sh-rehash
@@ -15,7 +15,7 @@ rbenv-rehash
 
 case "$shell" in
 fish )
-  echo "builtin history clear"
+  echo "builtin history clear 2>/dev/null; or true"
   ;;
 * )
   echo "hash -r 2>/dev/null || true"

--- a/libexec/rbenv-sh-rehash
+++ b/libexec/rbenv-sh-rehash
@@ -15,7 +15,7 @@ rbenv-rehash
 
 case "$shell" in
 fish )
-  # no rehash support
+  echo "builtin history clear"
   ;;
 * )
   echo "hash -r 2>/dev/null || true"

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -158,6 +158,6 @@ SH
 @test "sh-rehash in fish" {
   create_executable "2.0" "ruby"
   RBENV_SHELL=fish run rbenv-sh-rehash
-  assert_success "builtin history clear"
+  assert_success "builtin history clear 2>/dev/null; or true"
   assert [ -x "${RBENV_ROOT}/shims/ruby" ]
 }

--- a/test/rehash.bats
+++ b/test/rehash.bats
@@ -158,6 +158,6 @@ SH
 @test "sh-rehash in fish" {
   create_executable "2.0" "ruby"
   RBENV_SHELL=fish run rbenv-sh-rehash
-  assert_success ""
+  assert_success "builtin history clear"
   assert [ -x "${RBENV_ROOT}/shims/ruby" ]
 }


### PR DESCRIPTION
I'm reading the code of `libexec/rbenv-sh-rehash`, and I found [this line of code](https://github.com/rbenv/rbenv/blob/c4395e58201966d9f90c12bd6b7342e389e7a4cb/libexec/rbenv-sh-rehash#L18), which says that if the user's shell is Fish, we execute a no-op.  This is different from [what happens with other shells](https://github.com/rbenv/rbenv/blob/c4395e58201966d9f90c12bd6b7342e389e7a4cb/libexec/rbenv-sh-rehash#L21), where we clear the user's command history cache via the "hash -r" command.

It seems like the original call to "hash -r" was added in response to [this Github issue](https://github.com/rbenv/rbenv/issues/119), and that the no-op for the Fish shell was added as part of [this PR](https://github.com/rbenv/rbenv/commit/5bfec84432e63c46df4724918080abe488ba64b4#diff-5e6f35f443d9791b1df6bfa471777ba127d986dbe696840066ff3b8aee8be601).  But I don't see a Github issue related to the latter PR, or any discussion around why the Fish branch is a no-op.  So I'm curious why if there's a reason not to clear the command history if the user's shell is Fish, when it is cleared for other shells.

According to [the Fish docs](https://fishshell.com/docs/current/cmds/history.html), Fish supports the "history" command, which does something similar to Bash's "hash" command.  And "history clear" would achieve the same outcome as "hash -r".  So theoretically we could replace the no-op with "history clear".  According to [the docs](https://fishshell.com/docs/current/cmds/history.html), prefacing the command with "builtin" is the way to circumvent the "Are you sure?" prompt which otherwise appears after running this command.

<img width="887" alt="Screenshot 2023-10-19 at 11 28 47 AM" src="https://github.com/rbenv/rbenv/assets/3839713/b6328497-bdab-4754-996f-6e12c1cfc7c6">

I believe the `2>/dev/null` and `; or true` code is correct Fish syntax, but could use an extra set of eyes on that to confirm.