### PR TITLE
Move gem-rehash monkey patch

### DIFF
--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -10,27 +10,27 @@ hook = lambda do |installer|
   end
 end
 
-if defined?(Bundler::Installer) && Bundler::Installer.respond_to?(:install) && !Bundler::Installer.respond_to?(:install_without_rbenv_rehash)
+if defined?(Bundler::Installer) && Bundler::Installer.methods.include?(:install) && !Bundler::Installer.methods.include?(:install_without_rbenv_rehash)
   Bundler::Installer.class_eval do
-    class << self
-      alias install_without_rbenv_rehash install
-      def install(root, definition, options = {})
-        begin
-          if Gem.default_path.include?(Bundler.bundle_path.to_s)
-            bin_dir = Gem.bindir(Bundler.bundle_path.to_s)
-            bins_before = File.exist?(bin_dir) ? Dir.entries(bin_dir).size : 2
-          end
-        rescue
-          warn "rbenv: error in Bundler post-install hook (#{$!.class.name}: #{$!.message})"
-        end
+    private
 
-        result = install_without_rbenv_rehash(root, definition, options)
-
-        if bin_dir && File.exist?(bin_dir) && Dir.entries(bin_dir).size > bins_before
-          `rbenv rehash`
+    alias install_without_rbenv_rehash install
+    def install(options)
+      begin
+        if Gem.default_path.include?(Bundler.bundle_path.to_s)
+          bin_dir = Gem.bindir(Bundler.bundle_path.to_s)
+          bins_before = File.exist?(bin_dir) ? Dir.entries(bin_dir).size : 2
         end
-        result
+      rescue
+        warn "rbenv: error in Bundler post-install hook (#{$!.class.name}: #{$!.message})"
       end
+
+      result = install_without_rbenv_rehash(options)
+
+      if bin_dir && File.exist?(bin_dir) && Dir.entries(bin_dir).size > bins_before
+        `rbenv rehash`
+      end
+      result
     end
   end
 else

--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -10,7 +10,9 @@ hook = lambda do |installer|
   end
 end
 
-if defined?(Bundler::Installer) && Bundler::Installer.methods.include?(:install) && !Bundler::Installer.methods.include?(:install_without_rbenv_rehash)
+if defined?(Bundler::Installer) &&
+   Bundler::Installer.private_instance_methods.include?(:install) &&
+   !Bundler::Installer.private_instance_methods.include?(:install_without_rbenv_rehash)
   Bundler::Installer.class_eval do
     private
 

--- a/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
+++ b/rbenv.d/exec/gem-rehash/rubygems_plugin.rb
@@ -11,8 +11,8 @@ hook = lambda do |installer|
 end
 
 if defined?(Bundler::Installer) &&
-   Bundler::Installer.private_instance_methods.include?(:install) &&
-   !Bundler::Installer.private_instance_methods.include?(:install_without_rbenv_rehash)
+   Bundler::Installer.private_method_defined?(:install) &&
+   !Bundler::Installer.private_method_defined?(:install_without_rbenv_rehash)
   Bundler::Installer.class_eval do
     private
 


### PR DESCRIPTION
The `rubygems_plugin.rb` file doesn't get loaded until after `Bundler::Installer.install` is called, so target `Bundler::Installer#install` to fix invocation order issues.

Closes #1540