### PR TITLE
Update link to maintained version of Bats

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ uninstall from the system.
 
 ## Development
 
-Tests are executed using [Bats](https://github.com/sstephenson/bats):
+Tests are executed using [Bats](https://github.com/bats-core/bats-core):
 
     $ bats test
     $ bats test/<file>.bats


### PR DESCRIPTION
The old Bats was archived in 2021, the currently maintained fork uses a different repo which is not linked to from the old one.