### PR TITLE
rbenv shell: properly declare global variables for zsh

### DIFF
--- a/libexec/rbenv-sh-shell
+++ b/libexec/rbenv-sh-shell
@@ -48,6 +48,10 @@ if [ "$version" = "--unset" ]; then
     echo 'set -gu RBENV_VERSION_OLD "$RBENV_VERSION"'
     echo "set -e RBENV_VERSION"
     ;;
+  zsh )
+    echo "typeset -g RBENV_VERSION_OLD=\"${RBENV_VERSION-}\""
+    echo "unset RBENV_VERSION"
+    ;;
   * )
     echo 'RBENV_VERSION_OLD="${RBENV_VERSION-}"'
     echo "unset RBENV_VERSION"
@@ -74,6 +78,24 @@ else
   echo "rbenv: RBENV_VERSION_OLD is not set" >&2
   false
 end
+EOS
+    ;;
+  zsh )
+    cat <<EOS
+if [ -n "\${RBENV_VERSION_OLD+x}" ]; then
+  if [ -n "\$RBENV_VERSION_OLD" ]; then
+    local RBENV_VERSION_OLD_="\$RBENV_VERSION"
+    export RBENV_VERSION="\$RBENV_VERSION_OLD"
+    RBENV_VERSION_OLD="\$RBENV_VERSION_OLD_"
+    unset RBENV_VERSION_OLD_
+  else
+    typeset -g RBENV_VERSION_OLD="\$RBENV_VERSION"
+    unset RBENV_VERSION
+  fi
+else
+  echo "rbenv: RBENV_VERSION_OLD is not set" >&2
+  false
+fi
 EOS
     ;;
   * )
@@ -105,6 +127,10 @@ if rbenv-prefix "$version" >/dev/null; then
     fish )
       echo 'set -gu RBENV_VERSION_OLD "$RBENV_VERSION"'
       echo "set -gx RBENV_VERSION \"$version\""
+      ;;
+    zsh )
+      echo "typeset -g RBENV_VERSION_OLD=\"${RBENV_VERSION-}\""
+      echo "export RBENV_VERSION=\"$version\""
       ;;
     * )
       echo 'RBENV_VERSION_OLD="${RBENV_VERSION-}"'

--- a/libexec/rbenv-sh-shell
+++ b/libexec/rbenv-sh-shell
@@ -49,7 +49,7 @@ if [ "$version" = "--unset" ]; then
     echo "set -e RBENV_VERSION"
     ;;
   zsh )
-    echo "typeset -g RBENV_VERSION_OLD=\"${RBENV_VERSION-}\""
+    echo "typeset -g RBENV_VERSION_OLD=\"\${RBENV_VERSION-}\""
     echo "unset RBENV_VERSION"
     ;;
   * )
@@ -129,7 +129,7 @@ if rbenv-prefix "$version" >/dev/null; then
       echo "set -gx RBENV_VERSION \"$version\""
       ;;
     zsh )
-      echo "typeset -g RBENV_VERSION_OLD=\"${RBENV_VERSION-}\""
+      echo "typeset -g RBENV_VERSION_OLD=\"\${RBENV_VERSION-}\""
       echo "export RBENV_VERSION=\"$version\""
       ;;
     * )

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -80,6 +80,16 @@ export RBENV_VERSION="1.2.3"
 OUT
 }
 
+@test "shell change version (zsh)" {
+  mkdir -p "${RBENV_ROOT}/versions/1.2.3"
+  RBENV_SHELL=zsh run rbenv-sh-shell 1.2.3
+  assert_success
+  assert_output <<OUT
+typeset -g RBENV_VERSION_OLD="\${RBENV_VERSION-}"
+export RBENV_VERSION="1.2.3"
+OUT
+}
+
 @test "shell change version (fish)" {
   mkdir -p "${RBENV_ROOT}/versions/1.2.3"
   RBENV_SHELL=fish run rbenv-sh-shell 1.2.3


### PR DESCRIPTION
With zsh `setopt warn_create_global` the "shell" command used to cause a warning message:

    scalar parameter RBENV_VERSION_OLD created globally in function rbenv.

By using `typeset -g` specifically for zsh, this warning goes away.

Fixes https://github.com/rbenv/rbenv/issues/1257