### PR TITLE
rbenv init: modify shell config files instead of printing instructions

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for rbenv
-# Usage: eval "$(rbenv init - [--no-rehash] [<shell>])"
+# Usage: rbenv init [--no-rehash] [<shells>...]
+#        rbenv init - [--no-rehash] [<shell>]
+#
+# Modifies shell initialization files to bootstrap rbenv functionality.
+# Typically, this will add a line that eval's the output of `rbenv init -`.
+# If no shells are named by arguments, the current shell will be detected
+# by inspecting the parent process. If a shell is already configured for
+# rbenv, the init command does nothing and exits with zero status.
+#
+# In the `rbenv init -` mode, this outputs a script to be eval'd in the
+# current shell. Most importantly, that script prepends the rbenv shims
+# directory to the PATH environment variable. To aid interactive shells,
+# the script also installs the magic `rbenv()` shell function and loads
+# shell completions for rbenv commands.
 
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
@@ -18,27 +31,29 @@ fi
 
 print=""
 no_rehash=""
-for args in "$@"
-do
-  if [ "$args" = "-" ]; then
+shells=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+  "-" )
     print=1
-    shift
-  fi
-
-  if [ "$args" = "--no-rehash" ]; then
+    ;;
+  "--no-rehash" )
     no_rehash=1
-    shift
-  fi
+    ;;
+  * )
+    shells+=("$1")
+    ;;
+  esac
+  shift
 done
 
-shell="$1"
-if [ -z "$shell" ]; then
+if [ "${#shells[@]}" -eq 0 ]; then
   shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
   shell="${shell%% *}"
   shell="${shell##-}"
   shell="${shell:-$SHELL}"
   shell="${shell##*/}"
-  shell="${shell%%-*}"
+  shells=("${shell%%-*}")
 fi
 
 root="${BASH_SOURCE:-$0}"
@@ -51,62 +66,79 @@ if [ -n "$RBENV_ORIG_PATH" ]; then
 fi
 
 if [ -z "$print" ]; then
-  case "$shell" in
-  bash )
-    if [ -f "${HOME}/.bashrc" ] && [ ! -f "${HOME}/.bash_profile" ]; then
-      profile='~/.bashrc'
-    else
-      profile='~/.bash_profile'
-    fi
-    ;;
-  zsh )
-    profile='~/.zshrc'
-    ;;
-  ksh | ksh93 | mksh )
-    # There are two implementations of Korn shell: AT&T (ksh93) and Mir (mksh).
-    # Systems may have them installed under those names, or as ksh, so those
-    # are recognized here. The obsolete ksh88 (subsumed by ksh93) and pdksh
-    # (subsumed by mksh) are not included, since they are unlikely to still
-    # be in use as interactive shells anywhere.
-    profile='~/.profile'
-    ;;
-  fish )
-    profile='~/.config/fish/config.fish'
-    ;;
-  * )
-    profile='your profile'
-    ;;
-  esac
-
   rbenv_command=rbenv
   if [ -z "$rbenv_in_path" ]; then
     rbenv_command="$root/bin/rbenv"
     rbenv_command="${rbenv_command/$HOME\//~/}"
   fi
 
-  { echo "# Please add the following line to your \`${profile}' file,"
-    echo "# then restart your terminal."
-    echo
-    [ -t 2 ] && printf '\e[33;1m'
+  color_start=""
+  color_end=""
+  if [ -t 1 ]; then
+    color_start=$'\e[33;1m'
+    color_end=$'\e[m'
+  fi
+
+  write_config() {
+    if grep -q "rbenv init" "$1" 2>/dev/null; then
+      printf 'skipping %s%s%s: already configured for rbenv.\n' "$color_start" "${1/$HOME\//~/}" "$color_end"
+      return 0
+    fi
+    mkdir -p "${1%/*}"
+    # shellcheck disable=SC2016
+    printf '\n# Added by `rbenv init` on %s\n%s\n' "$(date)" "$2" >> "$1"
+    printf 'writing %s%s%s: now configured for rbenv.\n' "$color_start" "${1/$HOME\//~/}" "$color_end"
+  }
+
+  status=0
+  for shell in "${shells[@]}"; do
     case "$shell" in
+    bash )
+      if [ -f ~/.bashrc ] && [ ! -f ~/.bash_profile ]; then
+        profile="$HOME/.bashrc"
+      else
+        # shellcheck disable=SC2012
+        profile="$(ls ~/.bash_profile ~/.bash_login ~/.profile 2>/dev/null | head -n1)"
+        [ -n "$profile" ] || profile="$HOME/.bash_profile"
+      fi
+      write_config "$profile" \
+        "eval \"\$($rbenv_command init -${no_rehash:+ --no-rehash} bash)\""
+      ;;
+    zsh )
+      # check zshrc for backward compatibility with older rbenv init
+      if grep -q rbenv "${ZDOTDIR:-$HOME}/.zshrc" 2>/dev/null; then
+        profile="${ZDOTDIR:-$HOME}/.zshrc"
+      else
+        profile="${ZDOTDIR:-$HOME}/.zprofile"
+      fi
+      write_config "$profile" \
+        "eval \"\$($rbenv_command init -${no_rehash:+ --no-rehash} zsh)\""
+      ;;
+    ksh | ksh93 | mksh )
+      # There are two implementations of Korn shell: AT&T (ksh93) and Mir (mksh).
+      # Systems may have them installed under those names, or as ksh, so those
+      # are recognized here. The obsolete ksh88 (subsumed by ksh93) and pdksh
+      # (subsumed by mksh) are not included, since they are unlikely to still
+      # be in use as interactive shells anywhere.
+      write_config "$HOME/.profile" \
+        "eval \"\$($rbenv_command init - ksh)\""
+      ;;
     fish )
-      printf 'status --is-interactive; and %s init - fish | source' "$rbenv_command"
+      write_config "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" \
+        "status --is-interactive; and $rbenv_command init -${no_rehash:+ --no-rehash} fish | source"
       ;;
     * )
-      # shellcheck disable=SC2016
-      printf 'eval "$(%s init - %s)"' "$rbenv_command" "$shell"
+      printf 'unsupported shell: "%s"\n' "$shell" >&2
+      status=1
       ;;
     esac
-    [ -t 2 ] && printf '\e[m'
-    echo
-    echo
-  } >&2
-
-  exit 1
+  done
+  exit $status
 fi
 
 mkdir -p "${RBENV_ROOT}/"{shims,versions}
 
+shell="${shells[0]}"
 case "$shell" in
 fish )
   [ -n "$rbenv_in_path" ] || printf "set -gx PATH '%s/bin' \$PATH\n" "$root"

--- a/test/init.bats
+++ b/test/init.bats
@@ -51,16 +51,65 @@ OUT
   [ -z "$line" ] || flunk "did not expect line: $line"
 }
 
-@test "posix shell instructions" {
+@test "set up bash" {
+  assert [ ! -e ~/.bash_profile ]
   run rbenv-init bash
-  assert [ "$status" -eq 1 ]
+  assert_success "writing ~/.bash_profile: now configured for rbenv."
+  run cat ~/.bash_profile
+  # shellcheck disable=SC2016
   assert_line 'eval "$(rbenv init - bash)"'
 }
 
-@test "fish instructions" {
+@test "set up bash (bashrc)" {
+  mkdir -p "$HOME"
+  touch ~/.bashrc
+  assert [ ! -e ~/.bash_profile ]
+  run rbenv-init bash
+  assert_success "writing ~/.bashrc: now configured for rbenv."
+  run cat ~/.bashrc
+  # shellcheck disable=SC2016
+  assert_line 'eval "$(rbenv init - bash)"'
+}
+
+@test "set up zsh" {
+  unset ZDOTDIR
+  assert [ ! -e ~/.zprofile ]
+  run rbenv-init zsh
+  assert_success "writing ~/.zprofile: now configured for rbenv."
+  run cat ~/.zprofile
+  # shellcheck disable=SC2016
+  assert_line 'eval "$(rbenv init - zsh)"'
+}
+
+@test "set up zsh (zshrc)" {
+  unset ZDOTDIR
+  mkdir -p "$HOME"
+  cat > ~/.zshrc <<<"# rbenv"
+  run rbenv-init zsh
+  assert_success "writing ~/.zshrc: now configured for rbenv."
+  run cat ~/.zshrc
+  # shellcheck disable=SC2016
+  assert_line 'eval "$(rbenv init - zsh)"'
+}
+
+@test "set up fish" {
+  unset XDG_CONFIG_HOME
   run rbenv-init fish
-  assert [ "$status" -eq 1 ]
+  assert_success "writing ~/.config/fish/config.fish: now configured for rbenv."
+  run cat ~/.config/fish/config.fish
   assert_line 'status --is-interactive; and rbenv init - fish | source'
+}
+
+@test "set up multiple shells at once" {
+  unset ZDOTDIR
+  unset XDG_CONFIG_HOME
+  run rbenv-init bash zsh fish
+  assert_success
+  assert_output <<OUT
+writing ~/.bash_profile: now configured for rbenv.
+writing ~/.zprofile: now configured for rbenv.
+writing ~/.config/fish/config.fish: now configured for rbenv.
+OUT
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
When running `rbenv init`, typically during rbenv setup, users expected their shell environment to be modified permanently. Instead, what the command would do is print the instructions to the user and expect them to edit their shell initialization files accordingly. This proved to be unintuitive.

Now, running `rbenv init <shells>...` will modify the shell initialization files of the following shells:

- bash: `~/.bash_profile` or `~/.bashrc` if the latter exists but the former does not
- zsh: `~/.zprofile` or `~/.zshrc` if the latter exists and mentions "rbenv"
- fish: `~/.config/fish/config.fish`

If no shells were specified on the command line, rbenv will try to detect the current shell.

It should be safe to run `rbenv init` multiple times, as the command will avoid modifying any shell startup file that already mentions "rbenv init".