### PR TITLE
Removes redundant ruby-build from brew-install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ On systems with Homebrew package manager, the “Using Package Managers” metho
    On macOS or Linux, we recommend installing rbenv with [Homebrew](https://brew.sh).
    
    ```sh
-   brew install rbenv ruby-build
+   brew install rbenv
    ```
    
    #### Debian, Ubuntu, and their derivatives


### PR DESCRIPTION
This was already put in place by https://github.com/rbenv/rbenv/pull/863 but regressed with https://github.com/rbenv/rbenv/commit/e4f61e67e2336c86622e3efa0473e2c04add5c08

(And ruby-build is still included in rbenv's formula)