### PR TITLE
rbenv init in setup mode defaults to no auto-rehashing

### DIFF
--- a/libexec/rbenv-init
+++ b/libexec/rbenv-init
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Summary: Configure the shell environment for rbenv
-# Usage: rbenv init [--no-rehash] [<shells>...]
+# Usage: rbenv init [<shells>...]
 #        rbenv init - [--no-rehash] [<shell>]
 #
 # Modifies shell initialization files to bootstrap rbenv functionality.
@@ -110,7 +110,7 @@ if [ -z "$print" ]; then
         [ -n "$profile" ] || profile="$HOME/.bash_profile"
       fi
       write_config "$profile" \
-        "eval \"\$($rbenv_command init -${no_rehash:+ --no-rehash} bash)\""
+        "eval \"\$($rbenv_command init - --no-rehash bash)\""
       ;;
     zsh )
       # check zshrc for backward compatibility with older rbenv init
@@ -120,7 +120,7 @@ if [ -z "$print" ]; then
         profile="${ZDOTDIR:-$HOME}/.zprofile"
       fi
       write_config "$profile" \
-        "eval \"\$($rbenv_command init -${no_rehash:+ --no-rehash} zsh)\""
+        "eval \"\$($rbenv_command init - --no-rehash zsh)\""
       ;;
     ksh | ksh93 | mksh )
       # There are two implementations of Korn shell: AT&T (ksh93) and Mir (mksh).
@@ -133,7 +133,7 @@ if [ -z "$print" ]; then
       ;;
     fish )
       write_config "${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish" \
-        "status --is-interactive; and $rbenv_command init -${no_rehash:+ --no-rehash} fish | source"
+        "status --is-interactive; and $rbenv_command init - --no-rehash fish | source"
       ;;
     * )
       printf 'unsupported shell: "%s"\n' "$shell" >&2

--- a/test/init.bats
+++ b/test/init.bats
@@ -57,7 +57,7 @@ OUT
   assert_success "writing ~/.bash_profile: now configured for rbenv."
   run cat ~/.bash_profile
   # shellcheck disable=SC2016
-  assert_line 'eval "$(rbenv init - bash)"'
+  assert_line 'eval "$(rbenv init - --no-rehash bash)"'
 }
 
 @test "set up bash (bashrc)" {
@@ -68,7 +68,7 @@ OUT
   assert_success "writing ~/.bashrc: now configured for rbenv."
   run cat ~/.bashrc
   # shellcheck disable=SC2016
-  assert_line 'eval "$(rbenv init - bash)"'
+  assert_line 'eval "$(rbenv init - --no-rehash bash)"'
 }
 
 @test "set up zsh" {
@@ -78,7 +78,7 @@ OUT
   assert_success "writing ~/.zprofile: now configured for rbenv."
   run cat ~/.zprofile
   # shellcheck disable=SC2016
-  assert_line 'eval "$(rbenv init - zsh)"'
+  assert_line 'eval "$(rbenv init - --no-rehash zsh)"'
 }
 
 @test "set up zsh (zshrc)" {
@@ -89,7 +89,7 @@ OUT
   assert_success "writing ~/.zshrc: now configured for rbenv."
   run cat ~/.zshrc
   # shellcheck disable=SC2016
-  assert_line 'eval "$(rbenv init - zsh)"'
+  assert_line 'eval "$(rbenv init - --no-rehash zsh)"'
 }
 
 @test "set up fish" {
@@ -97,7 +97,7 @@ OUT
   run rbenv-init fish
   assert_success "writing ~/.config/fish/config.fish: now configured for rbenv."
   run cat ~/.config/fish/config.fish
-  assert_line 'status --is-interactive; and rbenv init - fish | source'
+  assert_line 'status --is-interactive; and rbenv init - --no-rehash fish | source'
 }
 
 @test "set up multiple shells at once" {


### PR DESCRIPTION
From now, when `rbenv init` is invoked to automatically edit shell startup files, the generated lines will be invoking `rbenv init - --no-rehash` by default to help speed up shell startup.

Auto-rehashing on every shell startup can be slow for some users but is not crucial to rbenv operation. Furthermore, if multiple shells are starting in parallel, (e.g. restoring multiple terminal tabs after OS restart), the rehash process fails as it's not parallelism-safe.

Lets assume that rbenv shims are already healthy and that they will be regenerated as needed after installing new ruby versions and gems.

For those users who already have the `eval "$(rbenv init -)"` line in their shell startup files, nothing changes. This is intentional to ensure backward compatibility.