### PR TITLE
Fix #1586: Add /usr/etc/rbenv.d to hooks path

### DIFF
--- a/libexec/rbenv
+++ b/libexec/rbenv
@@ -82,7 +82,7 @@ if [ ! "${libexec_dir%/*}"/rbenv.d -ef "$RBENV_ROOT"/rbenv.d ]; then
   # Add rbenv's own `rbenv.d` unless rbenv was cloned to RBENV_ROOT
   RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${libexec_dir%/*}/rbenv.d"
 fi
-RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
+RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:/usr/etc/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 for plugin_hook in "${RBENV_ROOT}/plugins/"*/etc/rbenv.d; do
   RBENV_HOOK_PATH="${RBENV_HOOK_PATH}:${plugin_hook}"
 done

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -78,5 +78,5 @@ load test_helper
 @test "RBENV_HOOK_PATH includes rbenv built-in plugins" {
   unset RBENV_HOOK_PATH
   run rbenv echo "RBENV_HOOK_PATH"
-  assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME%/*}/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
+  assert_success "${RBENV_ROOT}/rbenv.d:${BATS_TEST_DIRNAME%/*}/rbenv.d:/usr/etc/rbenv.d:/usr/local/etc/rbenv.d:/etc/rbenv.d:/usr/lib/rbenv/hooks"
 }

--- a/test/rbenv.bats
+++ b/test/rbenv.bats
@@ -64,7 +64,7 @@ load test_helper
 @test "RBENV_HOOK_PATH includes etc/rbenv.d folders" {
   mkdir -p "$RBENV_ROOT"/plugins/rbenv-foo/etc/rbenv.d
   run rbenv echo -F: "RBENV_HOOK_PATH"
-  assert_line 6 "${RBENV_ROOT}/plugins/rbenv-foo/etc/rbenv.d"
+  assert_line 7 "${RBENV_ROOT}/plugins/rbenv-foo/etc/rbenv.d"
 }
 
 @test "RBENV_HOOK_PATH preserves value from environment" {


### PR DESCRIPTION
Fixes #1586 

The directory `/usr/etc` is an optional directory and used by Fedora, RHEL 9, and openSUSE. The purpose of `/usr/etc` is to store distribution-provided configuration files that can be overridden by user-modified files in /etc.

Also used in the sister project pyenv/pyenv#3039