### PR TITLE
Use readarray in bash v4+ to avoid rbenv init hanging

### DIFF
--- a/libexec/rbenv-commands
+++ b/libexec/rbenv-commands
@@ -26,7 +26,12 @@ elif [ "$1" = "--no-sh" ]; then
   shift
 fi
 
-IFS=: read -d '' -r -a paths <<<"$PATH" || true
+if [ "$(type -t readarray)" = "builtin" ]; then
+  readarray -d : -t paths < <(printf "%s" "$PATH")
+else
+  # bash 3.x compatibility
+  IFS=: read -r -a paths <<<"$PATH" || true
+fi
 
 shopt -s nullglob
 

--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -154,7 +154,12 @@ print_usage() {
 if [ "$1" = "--complete-commands" ]; then
   command_prefix="${2:-}"
   seen=()
-  IFS=: read -d '' -r -a paths <<<"$PATH" || true
+  if [ "$(type -t readarray)" = "builtin" ]; then
+    readarray -d : -t paths < <(printf "%s" "$PATH")
+  else
+    # bash 3.x compatibility
+    IFS=: read -r -a paths <<<"$PATH" || true
+  fi
   shopt -s nullglob
   for path in "${paths[@]}"; do
     for command in "${path}/rbenv-${command_prefix}"*; do


### PR DESCRIPTION
For just a handful of people, rbenv init would hang indefinitely. Turning on debugging output suggested that the `read` expression to split PATH into a bash array was hanging, but I could never reproduce this myself. Instead, this uses bash v4+ `readarray` if it's available, or falls back to bash v3 `read` with the default DELIM being a newline character. This will cause a regression if any PATH entries contain a literal newline character, but hopefully people are not relying on such paths.

Fixes #1593
Followup to #1450