### PR TITLE
fix readarray -d invalid option

### DIFF
--- a/libexec/rbenv-commands
+++ b/libexec/rbenv-commands
@@ -26,10 +26,10 @@ elif [ "$1" = "--no-sh" ]; then
   shift
 fi
 
-if [ "$(type -t readarray)" = "builtin" ]; then
+if [ "$(type -t readarray)" = "builtin" ] && echo "" | readarray -d '' _ 2>/dev/null; then
   readarray -d : -t paths < <(printf "%s" "$PATH")
 else
-  # bash 3.x compatibility
+  # bash < 4.4 compatibility
   IFS=: read -r -a paths <<<"$PATH" || true
 fi
 


### PR DESCRIPTION
Only readarray @ Bash 4.4+ support -d option

https://github.com/rbenv/rbenv/pull/1604#issuecomment-2576749563

This fix allow Bash lower than 4.4 can still be worked with good old IFS read... instead