### PR TITLE
Fix traversing PATH for bash < 4.4

### DIFF
--- a/libexec/rbenv-commands
+++ b/libexec/rbenv-commands
@@ -18,37 +18,33 @@ if [ "$1" = "--complete" ]; then
   exit
 fi
 
+exclude_shell=
+command_prefix="rbenv-"
+
 if [ "$1" = "--sh" ]; then
-  sh=1
+  command_prefix="rbenv-sh-"
   shift
 elif [ "$1" = "--no-sh" ]; then
-  nosh=1
+  exclude_shell=1
   shift
-fi
-
-if [ "$(type -t readarray)" = "builtin" ]; then
-  readarray -d : -t paths < <(printf "%s" "$PATH")
-else
-  # bash 3.x compatibility
-  IFS=: read -r -a paths <<<"$PATH" || true
 fi
 
 shopt -s nullglob
 
-{ for path in "${paths[@]}"; do
-    for command in "${path}/rbenv-"*; do
-      command="${command##*rbenv-}"
-      if [ -n "$sh" ]; then
-        if [ "${command:0:3}" = "sh-" ]; then
-          echo "${command##sh-}"
+{
+  PATH_remain="$PATH"
+  # traverse PATH to find "rbenv-" prefixed commands
+  while true; do
+    path="${PATH_remain%%:*}"
+    if [ -n "$path" ]; then
+      for rbenv_command in "${path}/${command_prefix}"*; do
+        rbenv_command="${rbenv_command##*rbenv-}"
+        if [[ -z $exclude_shell || $rbenv_command != sh-* ]]; then
+          echo "${rbenv_command##sh-}"
         fi
-      elif [ -n "$nosh" ]; then
-        if [ "${command:0:3}" != "sh-" ]; then
-          echo "${command##sh-}"
-        fi
-      else
-        echo "${command##sh-}"
-      fi
-    done
+      done
+    fi
+    [[ $PATH_remain == *:* ]] || break
+    PATH_remain="${PATH_remain#*:}"
   done
 } | sort | uniq

--- a/libexec/rbenv-help
+++ b/libexec/rbenv-help
@@ -154,25 +154,27 @@ print_usage() {
 if [ "$1" = "--complete-commands" ]; then
   command_prefix="${2:-}"
   seen=()
-  if [ "$(type -t readarray)" = "builtin" ]; then
-    readarray -d : -t paths < <(printf "%s" "$PATH")
-  else
-    # bash 3.x compatibility
-    IFS=: read -r -a paths <<<"$PATH" || true
-  fi
   shopt -s nullglob
-  for path in "${paths[@]}"; do
-    for command in "${path}/rbenv-${command_prefix}"*; do
-      command_name="${command##*/}"
-      command_name="${command_name#rbenv-}"
-      command_name="${command_name#sh-}"
-      [[ " ${seen[*]} " != *" ${command_name} "* ]] || continue
-      seen+=("$command_name")
-      summary=""
-      eval "$(extract_initial_comment_block < "$command" | collect_documentation)"
-      [ -n "$summary" ] || continue
-      printf "%s:%s\n" "$command_name" "$summary"
-    done
+  PATH_remain="$PATH"
+  # traverse PATH to find "rbenv-" prefixed commands
+  while true; do
+    path="${PATH_remain%%:*}"
+    if [ -n "$path" ]; then
+      for rbenv_command in "${path}/rbenv-"*; do
+        command_name="${rbenv_command##*/}"
+        command_name="${command_name#rbenv-}"
+        command_name="${command_name#sh-}"
+        [[ $command_name == "${command_prefix}"* ]] || continue
+        [[ " ${seen[*]} " != *" ${command_name} "* ]] || continue
+        seen+=("$command_name")
+        summary=""
+        eval "$(extract_initial_comment_block < "$rbenv_command" | collect_documentation)"
+        [ -n "$summary" ] || continue
+        printf "%s:%s\n" "$command_name" "$summary"
+      done
+    fi
+    [[ $PATH_remain == *:* ]] || break
+    PATH_remain="${PATH_remain#*:}"
   done
   exit 0
 fi


### PR DESCRIPTION
Bash versions before 4.4 did not support the `-d` nor `-t` flags for readarray: https://lists.gnu.org/archive/html/info-gnu/2016-09/msg00012.html

Reported by @tobias-pwnr in https://github.com/rbenv/rbenv/pull/1604#issuecomment-2576749563

This switches away from readarray/`read` completely in favor of traversing PATH by using string substitution.

Closes #1605