### PR TITLE
Update README.md fixed inactive hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On systems with Homebrew package manager, the “Using Package Managers” metho
    
    #### Arch Linux and its derivatives
    
-   Archlinux has an [AUR Package](https://aur.archlinux.org/packages/rbenv/) for
+   Archlinux has an [AUR Package](https://wiki.archlinux.org/title/Rbenv) for
    rbenv and you can install it from the AUR using the instructions from this
    [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages).
 


### PR DESCRIPTION
Arch added rbenv to repo extra so I fixed old inactive link to AUR in README for consistency
Maybe it should be this one instead [https://archlinux.org/packages/extra/any/rbenv/](https://archlinux.org/packages/extra/any/rbenv/)