### PR TITLE
Update README.md; fixed inactive AUR hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ On systems with Homebrew package manager, the “Using Package Managers” metho
    
    #### Arch Linux and its derivatives
    
-   Archlinux has an [AUR Package](https://aur.archlinux.org/packages/rbenv/) for
-   rbenv and you can install it from the AUR using the instructions from this
-   [wiki page](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages).
+   Archlinux has an [official package](https://archlinux.org/packages/extra/any/rbenv/) which you can install:
+
+   ```sh
+   sudo pacman -S rbenv
+   ```
 
    #### Fedora
 


### PR DESCRIPTION
Arch Linux moved`rbenv` to the extra repository, so I updated the `README`by replacing an old, inactive link to the AUR with installation instructions for the official repository.
 I noticed that the official `rbenv` package includes a post-installation notification about initializing `rbenv`(see [HERE](https://gitlab.archlinux.org/archlinux/packaging/packages/rbenv/-/blob/main/rbenv.install?ref_type=heads)). I’m unsure if it should be mentioned in the `README`—please let me know your thoughts! The repository package is well-maintained and kept up to date.
 I’ll ensure the `rbenv` repository isn’t deleted before the merge this time. Thank you!